### PR TITLE
make a dynamic delay on the call back of the (handleNotificationOpened)

### DIFF
--- a/CleverPush/CleverPush/Source/CleverPush.h
+++ b/CleverPush/CleverPush/Source/CleverPush.h
@@ -71,6 +71,9 @@ extern NSString * const CLEVERPUSH_SDK_VERSION;
    handleNotificationReceived:(CPHandleNotificationReceivedBlock)receivedCallback
    handleNotificationOpened:(CPHandleNotificationOpenedBlock)openedCallback handleSubscribed:(CPHandleSubscribedBlock)subscribedCallback autoRegister:(BOOL)autoRegister;
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions channelId:(NSString*)channelId handleNotificationOpened:(CPHandleNotificationOpenedBlock)openedCallback handleSubscribed:(CPHandleSubscribedBlock)subscribedCallback autoRegister:(BOOL)autoRegister;
++ (id)initWithLaunchOptions:(NSDictionary*)launchOptions channelId:(NSString*)channelId handleNotificationOpened:(CPHandleNotificationOpenedBlock)openedCallback handleSubscribed:(CPHandleSubscribedBlock)subscribedCallback delay:(NSString*)seconds;
+
++ (void)delayCallback: (void(^)(void))callback forTotalSeconds: (double)delayInSeconds;
 + (void)setTrackingConsentRequired:(BOOL)required;
 + (void)setTrackingConsent:(BOOL)consent;
 + (void)enableDevelopmentMode;
@@ -82,6 +85,7 @@ extern NSString * const CLEVERPUSH_SDK_VERSION;
 + (void)unsubscribe;
 + (void)unsubscribe:(void(^)(BOOL))callback;
 + (void)syncSubscription;
++ (double)value;
 + (void)didRegisterForRemoteNotifications:(UIApplication*)app deviceToken:(NSData*)inDeviceToken;
 + (void)handleDidFailRegisterForRemoteNotification:(NSError*)err;
 + (void)handleNotificationOpened:(NSDictionary*)messageDict isActive:(BOOL)isActive actionIdentifier:(NSString*)actionIdentifier;

--- a/CleverPush/CleverPush/Source/CleverPush.m
+++ b/CleverPush/CleverPush/Source/CleverPush.m
@@ -78,6 +78,7 @@ static BOOL autoRegister = YES;
 static BOOL registrationInProgress = false;
 
 static NSString* channelId;
+static NSString* callBackDelay;
 static NSString* lastNotificationReceivedId;
 static NSString* lastNotificationOpenedId;
 static NSDictionary* channelConfig;
@@ -199,6 +200,12 @@ static id isNil(id object) {
     return [self initWithLaunchOptions:launchOptions channelId:channelId handleNotificationOpened:openedCallback handleSubscribed:subscribedCallback autoRegister:YES];
 }
 
++ (id)initWithLaunchOptions:(NSDictionary*)launchOptions channelId:(NSString*)channelId handleNotificationOpened:(CPHandleNotificationOpenedBlock)openedCallback handleSubscribed:(CPHandleSubscribedBlock)subscribedCallback delay:(NSString*)seconds
+{
+    callBackDelay = seconds;
+    return [self initWithLaunchOptions:launchOptions channelId:channelId handleNotificationOpened:openedCallback handleSubscribed:subscribedCallback autoRegister:YES];
+}
+
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions channelId:(NSString*)channelId
  handleNotificationReceived:(CPHandleNotificationReceivedBlock)receivedCallback
    handleNotificationOpened:(CPHandleNotificationOpenedBlock)openedCallback handleSubscribed:(CPHandleSubscribedBlock)subscribedCallback {
@@ -228,6 +235,16 @@ static id isNil(id object) {
 
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions channelId:(NSString*)newChannelId handleNotificationOpened:(CPHandleNotificationOpenedBlock)openedCallback handleSubscribed:(CPHandleSubscribedBlock)subscribedCallback autoRegister:(BOOL)autoRegisterParam {
     return [self initWithLaunchOptions:launchOptions channelId:newChannelId handleNotificationReceived:NULL handleNotificationOpened:openedCallback handleSubscribed:subscribedCallback autoRegister:autoRegisterParam];
+}
+
++ (void) delayCallback: (void(^)(void))callback forTotalSeconds: (double)delayInSeconds{
+
+     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, delayInSeconds * NSEC_PER_SEC);
+     dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+           if(callback){
+                callback();
+           }
+      });
 }
 
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions


### PR DESCRIPTION
as there was a bug when you open-up an application via notification with a delay of few seconds while your application is in inactive state, It was not working before so I have added new initWithLaunchOptions function in CleverPush.h/.m in which you can add your desire delay on initialisation of SDK