### PR TITLE
Cp 1422 sdk check delayed init with sync async

### DIFF
--- a/CleverPush/CleverPush/Source/UNUserNotificationCenter+CleverPush.m
+++ b/CleverPush/CleverPush/Source/UNUserNotificationCenter+CleverPush.m
@@ -99,7 +99,7 @@ withCompletionHandler:(void(^)())completionHandler {
     NSLog(@"CleverPush cleverPushUserNotificationCenter didReceiveNotificationResponse");
     
     if (![CleverPush channelId]) {
-        return;
+//        return;
     }
     
     if ([CleverPushUNUserNotificationCenter isDismissEvent:response]) {

--- a/CleverPush/CleverPush/Source/UNUserNotificationCenter+CleverPush.m
+++ b/CleverPush/CleverPush/Source/UNUserNotificationCenter+CleverPush.m
@@ -99,7 +99,9 @@ withCompletionHandler:(void(^)())completionHandler {
     NSLog(@"CleverPush cleverPushUserNotificationCenter didReceiveNotificationResponse");
     
     if (![CleverPush channelId]) {
+
 //        return;
+
     }
     
     if ([CleverPushUNUserNotificationCenter isDismissEvent:response]) {


### PR DESCRIPTION
Have checked with both the scenario with Asynchronous and synchronous Initialisation and notification is working as expected in an all the application state (foreground, background, terminated) without duplicate call of the handler. 