### PR TITLE
CP-2044 Open notifications in Webview if no opened handler is set

### DIFF
--- a/CleverPush/CleverPush/Source/CleverPush.h
+++ b/CleverPush/CleverPush/Source/CleverPush.h
@@ -135,6 +135,7 @@ extern NSString * const CLEVERPUSH_SDK_VERSION;
 + (void)updateBadge:(UNMutableNotificationContent*)replacementContent API_AVAILABLE(ios(10.0));
 + (void)addStoryView:(CPStoryView*)storyView;
 + (void)updateDeselectFlag:(BOOL)value;
++ (void)setWebViewOpenedEnabled:(BOOL)opened;
 + (UIViewController*)topViewController;
 
 + (NSArray*)getAvailableTags __attribute__((deprecated));

--- a/CleverPush/CleverPush/Source/CleverPush.h
+++ b/CleverPush/CleverPush/Source/CleverPush.h
@@ -135,7 +135,7 @@ extern NSString * const CLEVERPUSH_SDK_VERSION;
 + (void)updateBadge:(UNMutableNotificationContent*)replacementContent API_AVAILABLE(ios(10.0));
 + (void)addStoryView:(CPStoryView*)storyView;
 + (void)updateDeselectFlag:(BOOL)value;
-+ (void)setWebViewOpenedEnabled:(BOOL)opened;
++ (void)setOpenWebViewEnabled:(BOOL)opened;
 + (UIViewController*)topViewController;
 
 + (NSArray*)getAvailableTags __attribute__((deprecated));

--- a/CleverPush/CleverPush/Source/CleverPush.m
+++ b/CleverPush/CleverPush/Source/CleverPush.m
@@ -120,6 +120,7 @@ BOOL channelTopicsPickerVisible = NO;
 BOOL developmentMode = NO;
 BOOL trackingConsentRequired = NO;
 BOOL hasTrackingConsent = NO;
+BOOL hasWebViewOpened = NO;
 BOOL hasTrackingConsentCalled = NO;
 BOOL handleSubscribedCalled = NO;
 
@@ -1251,9 +1252,11 @@ static id isNil(id object) {
         pendingOpenedResult = result;
     }
     if (!handleNotificationOpened) {
-        if (notification != nil && [notification valueForKey:@"url"] != nil && [[notification valueForKey:@"url"] length] != 0 && ![[notification valueForKey:@"url"] isKindOfClass:[NSNull class]]) {
-            NSURL *url = [NSURL URLWithString:[notification valueForKey:@"url"]];
-            [CPUtils openSafari:url];
+        if (hasWebViewOpened) {
+            if (notification != nil && [notification valueForKey:@"url"] != nil && [[notification valueForKey:@"url"] length] != 0 && ![[notification valueForKey:@"url"] isKindOfClass:[NSNull class]]) {
+                NSURL *url = [NSURL URLWithString:[notification valueForKey:@"url"]];
+                [CPUtils openSafari:url];
+            }
         }
         return;
     }
@@ -2349,6 +2352,11 @@ static id isNil(id object) {
 + (void)updateDeselectFlag:(BOOL)value{
     [[NSUserDefaults standardUserDefaults] setBool:value forKey:@"CleverPush_DESELECT_ALL"];
     [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+#pragma mark - update the hasWebViewOpened value based on the user's Boolean argument.
++ (void)setWebViewOpenedEnabled:(BOOL)opened {
+    hasWebViewOpened = opened;
 }
 
 #pragma mark - retrieve Deselect value from UserDefaults

--- a/CleverPush/CleverPush/Source/CleverPush.m
+++ b/CleverPush/CleverPush/Source/CleverPush.m
@@ -2354,7 +2354,7 @@ static id isNil(id object) {
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
-#pragma mark - Automatically a SFWebViewController on notification click when no Notification Opened Handler has been provided.
+#pragma mark - Automatically a SafariViewController on notification click when no Notification Opened Handler has been provided.
 + (void)setOpenWebViewEnabled:(BOOL)opened {
     hasWebViewOpened = opened;
 }

--- a/CleverPush/CleverPush/Source/CleverPush.m
+++ b/CleverPush/CleverPush/Source/CleverPush.m
@@ -2354,8 +2354,8 @@ static id isNil(id object) {
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
-#pragma mark - update the hasWebViewOpened value based on the user's Boolean argument.
-+ (void)setWebViewOpenedEnabled:(BOOL)opened {
+#pragma mark - Automatically a SFWebViewController on notification click when no Notification Opened Handler has been provided.
++ (void)setOpenWebViewEnabled:(BOOL)opened {
     hasWebViewOpened = opened;
 }
 

--- a/CleverPush/CleverPush/Source/CleverPush.m
+++ b/CleverPush/CleverPush/Source/CleverPush.m
@@ -1251,6 +1251,10 @@ static id isNil(id object) {
         pendingOpenedResult = result;
     }
     if (!handleNotificationOpened) {
+        if (notification != nil && [notification valueForKey:@"url"] != nil && [[notification valueForKey:@"url"] length] != 0 && ![[notification valueForKey:@"url"] isKindOfClass:[NSNull class]]) {
+            NSURL *url = [NSURL URLWithString:[notification valueForKey:@"url"]];
+            [CPUtils openSafari:url];
+        }
         return;
     }
     


### PR DESCRIPTION
**Notification Support** : If you didn't assign notification open handler during the channel initialisation and if the notification payload contain any valid callback URL from **CleverPush** console it will open-up that **URL** in **SFSafariViewController**.