### PR TITLE
CP-2172-The dialog will only open if config contains at least one topic.

### DIFF
--- a/CleverPush/CleverPush/Source/CleverPush.m
+++ b/CleverPush/CleverPush/Source/CleverPush.m
@@ -2314,6 +2314,7 @@ static id isNil(id object) {
         channelTopics = channelTopics_;
         if ([channelTopics count] == 0) {
             NSLog(@"CleverPush: showTopicsDialog: No topics found. Create some first in the CleverPush channel settings.");
+            return;
         }
         
         [self getChannelConfig:^(NSDictionary* channelConfig) {


### PR DESCRIPTION
CP-2172-Empty Topic Dialog Support.
file changes.
`CleverPush.m` >>> `showTopicsDialog:(UIWindow *)targetWindow`
Validation check was already there we were just need to make an exit call before dialog screen gets present.