### PR TITLE
hotfix/CP-2230-iOS testing commit.

### DIFF
--- a/CleverPush.podspec
+++ b/CleverPush.podspec
@@ -7,7 +7,6 @@ Pod::Spec.new do |s|
     s.author                  = { "CleverPush" => "support@cleverpush.com" }
     s.ios.deployment_target   = "9.0"
     s.source                  = { :git => "https://github.com/cleverpush/cleverpush-ios-sdk.git", :tag => s.version.to_s }
-    s.source_files            = 'CleverPush/Source/.{h,m}'
     s.resources               = ['CleverPush/Source/CPTopicDialogCell.xib']
     s.platform                = :ios
     s.requires_arc            = true

--- a/CleverPush.podspec
+++ b/CleverPush.podspec
@@ -7,6 +7,8 @@ Pod::Spec.new do |s|
     s.author                  = { "CleverPush" => "support@cleverpush.com" }
     s.ios.deployment_target   = "9.0"
     s.source                  = { :git => "https://github.com/cleverpush/cleverpush-ios-sdk.git", :tag => s.version.to_s }
+    s.source_files            = 'CleverPush/Source/.{h,m}'
+    s.resources               = ['CleverPush/Source/CPTopicDialogCell.xib']
     s.platform                = :ios
     s.requires_arc            = true
     s.framework               = "SystemConfiguration", "UIKit", "UserNotifications", "StoreKit", "WebKit", "JavaScriptCore", "SafariServices"

--- a/CleverPush/CleverPush.xcodeproj/project.pbxproj
+++ b/CleverPush/CleverPush.xcodeproj/project.pbxproj
@@ -213,6 +213,8 @@
 		CB88F900262FE91E0037787E /* CPWKWebKitView.m in Sources */ = {isa = PBXBuildFile; fileRef = CB88F8FF262FE91E0037787E /* CPWKWebKitView.m */; };
 		CB88F909262FE9520037787E /* CPWKWebKitView.h in Headers */ = {isa = PBXBuildFile; fileRef = CB88F8FE262FE91E0037787E /* CPWKWebKitView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB88F91A262FE9570037787E /* CPWKWebKitView.m in Sources */ = {isa = PBXBuildFile; fileRef = CB88F8FF262FE91E0037787E /* CPWKWebKitView.m */; };
+		CB913BBA26F08803000BB09B /* CPTopicDialogCell.xib in Sources */ = {isa = PBXBuildFile; fileRef = CBA1906826DE5909001B8F39 /* CPTopicDialogCell.xib */; };
+		CB913BBB26F0880D000BB09B /* CPTopicDialogCell.xib in Sources */ = {isa = PBXBuildFile; fileRef = CBA1906826DE5909001B8F39 /* CPTopicDialogCell.xib */; };
 		CBA1906926DE5909001B8F39 /* CPTopicDialogCell.h in Headers */ = {isa = PBXBuildFile; fileRef = CBA1906626DE5909001B8F39 /* CPTopicDialogCell.h */; };
 		CBA1906A26DE5909001B8F39 /* CPTopicDialogCell.m in Sources */ = {isa = PBXBuildFile; fileRef = CBA1906726DE5909001B8F39 /* CPTopicDialogCell.m */; };
 		CBA1906B26DE5909001B8F39 /* CPTopicDialogCell.m in Sources */ = {isa = PBXBuildFile; fileRef = CBA1906726DE5909001B8F39 /* CPTopicDialogCell.m */; };
@@ -1047,6 +1049,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB913BBA26F08803000BB09B /* CPTopicDialogCell.xib in Sources */,
 				CBA1906A26DE5909001B8F39 /* CPTopicDialogCell.m in Sources */,
 				291FCF05252B670A00F5185E /* DWAlertViewActionButton.m in Sources */,
 				29DB578923D75C8A0040E823 /* CPiCarousel.m in Sources */,
@@ -1114,6 +1117,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB913BBB26F0880D000BB09B /* CPTopicDialogCell.xib in Sources */,
 				291FCD262525DC2800F5185E /* DWAlertDismissalAnimationController.m in Sources */,
 				298F4FC125002D6700F086D3 /* CPUtils.m in Sources */,
 				29DB960123FC3763008FC985 /* CleverPush.m in Sources */,

--- a/CleverPush/CleverPush/Source/CPTopicDialogCell.xib
+++ b/CleverPush/CleverPush/Source/CPTopicDialogCell.xib
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>


### PR DESCRIPTION
- Target membership was not there for `CPTopicDialogCell.xib` so added target membership for the `ClevePushFramework` and update podspec for its resources. 