### PR TITLE
CP-2249-Topic dialog support.

### DIFF
--- a/CleverPush/CleverPush/Source/CPAppBanner.h
+++ b/CleverPush/CleverPush/Source/CPAppBanner.h
@@ -11,6 +11,7 @@
 #import "CPAppBannerTrigger.h"
 #import "CPAppBannerTriggerType.h"
 #import "CPAppBannerHTMLBlock.h"
+#import "CPUtils.h"
 
 @interface CPAppBanner : NSObject
 

--- a/CleverPush/CleverPush/Source/CPAppBanner.m
+++ b/CleverPush/CleverPush/Source/CPAppBanner.m
@@ -53,15 +53,11 @@
             }
         }
         
-        NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-        [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
-        [formatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
-        
         if ([[json objectForKey:@"startAt"] isKindOfClass:[NSString class]]) {
-            self.startAt = [formatter dateFromString:[json objectForKey:@"startAt"]];
+            self.startAt = [CPUtils getLocalDateTimeFromUTC:[json objectForKey:@"startAt"]];
         }
         if ([[json objectForKey:@"stopAt"] isKindOfClass:[NSString class]]) {
-            self.stopAt = [formatter dateFromString:[json objectForKey:@"stopAt"]];
+            self.stopAt = [CPUtils getLocalDateTimeFromUTC:[json objectForKey:@"stopAt"]];
         }
         
         if ([[json objectForKey:@"dismissType"] isEqual:@"timeout"]) {

--- a/CleverPush/CleverPush/Source/CPChannelTag.h
+++ b/CleverPush/CleverPush/Source/CPChannelTag.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-
+#import "CPUtils.h"
 @interface CPChannelTag : NSObject
 
 #pragma mark - Class Variables

--- a/CleverPush/CleverPush/Source/CPChannelTag.m
+++ b/CleverPush/CleverPush/Source/CPChannelTag.m
@@ -23,13 +23,9 @@
     _autoAssignSessions = [json objectForKey:@"autoAssignSessions"];
     _autoAssignSeconds = [json objectForKey:@"autoAssignSeconds"];
     _autoAssignDays = [json objectForKey:@"autoAssignDays"];
-    
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
-    [formatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
-    
+        
     if ([[json objectForKey:@"createdAt"] isKindOfClass:[NSString class]]) {
-        _createdAt = [formatter dateFromString:[json objectForKey:@"createdAt"]];
+        _createdAt = [CPUtils getLocalDateTimeFromUTC:[json objectForKey:@"createdAt"]];
     }
 }
 

--- a/CleverPush/CleverPush/Source/CPChannelTopic.h
+++ b/CleverPush/CleverPush/Source/CPChannelTopic.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-
+#import "CPUtils.h"
 @interface CPChannelTopic : NSObject
 #pragma mark - Class Variables
 @property (readonly, nullable) NSString *id;

--- a/CleverPush/CleverPush/Source/CPChannelTopic.m
+++ b/CleverPush/CleverPush/Source/CPChannelTopic.m
@@ -26,13 +26,9 @@
     if ([json objectForKey:@"defaultUnchecked"] != nil && ![[json objectForKey:@"defaultUnchecked"] isKindOfClass:[NSNull class]] && [[json objectForKey:@"defaultUnchecked"] boolValue]) {
         _defaultUnchecked = YES;
     }
-    
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
-    [formatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
-    
+        
     if ([[json objectForKey:@"createdAt"] isKindOfClass:[NSString class]]) {
-        _createdAt = [formatter dateFromString:[json objectForKey:@"createdAt"]];
+        _createdAt = [CPUtils getLocalDateTimeFromUTC:[json objectForKey:@"createdAt"]];
     }
 }
 

--- a/CleverPush/CleverPush/Source/CPNotification.h
+++ b/CleverPush/CleverPush/Source/CPNotification.h
@@ -1,5 +1,4 @@
 #import <Foundation/Foundation.h>
-
 @interface CPNotification : NSObject
 NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Class Variables

--- a/CleverPush/CleverPush/Source/CPNotification.m
+++ b/CleverPush/CleverPush/Source/CPNotification.m
@@ -1,4 +1,5 @@
 #import "CPNotification.h"
+#import "CPUtils.h"
 
 @implementation CPNotification
 #pragma mark - Initialise notifications by NSDictionary
@@ -68,16 +69,12 @@
         }];
         self.actions = actionArray;
     }
-    
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
-    [formatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
-    
+        
     if ([[json objectForKey:@"createdAt"] isKindOfClass:[NSString class]]) {
-        self.createdAt = [formatter dateFromString:[json objectForKey:@"createdAt"]];
+        self.createdAt = [CPUtils getLocalDateTimeFromUTC:[json objectForKey:@"createdAt"]];
     }
     if ([[json objectForKey:@"expiresAt"] isKindOfClass:[NSString class]]) {
-        self.expiresAt = [formatter dateFromString:[json objectForKey:@"expiresAt"]];
+        self.expiresAt = [CPUtils getLocalDateTimeFromUTC:[json objectForKey:@"expiresAt"]];
     }
     
     self.chatNotification = NO;

--- a/CleverPush/CleverPush/Source/CPStory.m
+++ b/CleverPush/CleverPush/Source/CPStory.m
@@ -1,5 +1,5 @@
 #import "CPStory.h"
-
+#import "CPUtils.h"
 @implementation CPStory
 
 #pragma mark - Initialise stories by NSDictionary
@@ -46,14 +46,11 @@
             self.viewsOrganic = [json objectForKey:@"viewsOrganic"];
         }
         
-        NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-        [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
-        [formatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
         if ([[json objectForKey:@"createdAt"] isKindOfClass:[NSString class]]) {
-            self.createdAt = [formatter dateFromString:[json objectForKey:@"createdAt"]];
+            self.createdAt = [CPUtils getLocalDateTimeFromUTC:[json objectForKey:@"createdAt"]];
         }
         if ([[json objectForKey:@"validatedAt"] isKindOfClass:[NSString class]]) {
-            self.validatedAt = [formatter dateFromString:[json objectForKey:@"validatedAt"]];
+            self.validatedAt = [CPUtils getLocalDateTimeFromUTC:[json objectForKey:@"validatedAt"]];
         }
         
         self.published = NO;

--- a/CleverPush/CleverPush/Source/CPStoryWidget.m
+++ b/CleverPush/CleverPush/Source/CPStoryWidget.m
@@ -1,5 +1,5 @@
 #import "CPStoryWidget.h"
-
+#import "CPUtils.h"
 NS_ASSUME_NONNULL_BEGIN
 @implementation CPStoryWidget
 #pragma mark - wrapping the data of the Widget in to CPWidget NSObject
@@ -25,13 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
         if ([json objectForKey:@"margin"] != nil && ![[json objectForKey:@"margin"] isKindOfClass:[NSNull class]]) {
             self.margin = [json objectForKey:@"margin"];
         }
-        
-        NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-        [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
-        [formatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
-        
+                
         if ([[json objectForKey:@"createdAt"] isKindOfClass:[NSString class]]) {
-            self.createdAt = [formatter dateFromString:[json objectForKey:@"createdAt"]];
+            self.createdAt = [CPUtils getLocalDateTimeFromUTC:[json objectForKey:@"createdAt"]];
         }
         
         if ([[json objectForKey:@"variant"] isEqual:@"bubbles"]) {

--- a/CleverPush/CleverPush/Source/CPTopicsViewController.m
+++ b/CleverPush/CleverPush/Source/CPTopicsViewController.m
@@ -19,7 +19,7 @@ static CGFloat const CPConstraints = 30.0;
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
-    [CPUtils updateLastCheckedTime];
+    [CPUtils updateLastTopicCheckedTime];
 }
 
 - (NSBundle *)getAssetsBundle {
@@ -341,7 +341,7 @@ static CGFloat const CPConstraints = 30.0;
     }
     NSDate *addedCacheDelay = [[topic createdAt] dateByAddingTimeInterval:+60*60];
     NSComparisonResult result;
-    result = [addedCacheDelay compare:[CPUtils getLastCheckedTime]];
+    result = [addedCacheDelay compare:[CPUtils getLastTopicCheckedTime]];
     
     if (self.topicsDialogShowWhenNewAdded && result == NSOrderedDescending) {
         cell.topicHighlighter.hidden = NO;

--- a/CleverPush/CleverPush/Source/CPUtils.h
+++ b/CleverPush/CleverPush/Source/CPUtils.h
@@ -9,8 +9,8 @@
 + (NSString*)downloadMedia:(NSString*)urlString;
 + (NSDictionary *)dictionaryWithPropertiesOfObject:(id)obj;
 + (NSInteger)daysBetweenDate:(NSDate*)fromDateTime andDate:(NSDate*)toDateTime;
-+ (void)updateLastCheckedTime;
-+ (NSDate*)getLastCheckedTime;
++ (void)updateLastTopicCheckedTime;
++ (NSDate*)getLastTopicCheckedTime;
 + (NSString *)hexStringFromColor:(UIColor *)color;
 + (BOOL)fontFamilyExists:(NSString*)fontFamily;
 + (BOOL)isEmpty:(id)thing;
@@ -18,4 +18,10 @@
 + (CGFloat)frameHeightWithoutSafeArea;
 + (void)openSafari:(NSURL*)URL dismissViewController:(UIViewController*)controller;
 + (NSString*)deviceName;
++ (void)updateLastTimeAutomaticallyShowed;
++ (NSDate*)getLastTimeAutomaticallyShowed;
++ (BOOL)newTopicAdded:(NSDictionary*)config;
++ (NSDate*)getLocalDateTimeFromUTC:(NSString*)dateString;
++ (NSInteger)secondsBetweenDate:(NSDate*)fromDateTime andDate:(NSDate*)toDateTime;
+
 @end

--- a/CleverPush/CleverPush/Source/CPUtils.m
+++ b/CleverPush/CleverPush/Source/CPUtils.m
@@ -5,6 +5,8 @@
 #import <sys/utsname.h>
 static BOOL existanceOfNewTopic = NO;
 static BOOL topicsDialogShowWhenNewAdded = NO;
+NSString * const dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+NSString * const localeIdentifier = @"en_US_POSIX";
 
 #pragma mark - Custom delegate of download
 @interface DirectDownloadDelegate : NSObject <NSURLSessionDataDelegate> {
@@ -476,8 +478,8 @@ static BOOL topicsDialogShowWhenNewAdded = NO;
 #pragma mark - convert UTC date in to local date.
 + (NSDate*)getLocalDateTimeFromUTC:(NSString*)dateString {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
-    [formatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
+    [formatter setDateFormat:dateFormat];
+    [formatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:localeIdentifier]];
     NSDate *localDate = [formatter dateFromString:dateString];
     return localDate;
 }

--- a/CleverPush/CleverPush/Source/CleverPush.h
+++ b/CleverPush/CleverPush/Source/CleverPush.h
@@ -121,6 +121,7 @@ extern NSString * const CLEVERPUSH_SDK_VERSION;
 + (void)setIncrementBadge:(BOOL)increment;
 + (void)addChatView:(CPChatView*)chatView;
 + (void)showTopicsDialog;
++ (void)showTopicDialogOnNewAdded;
 + (void)showTopicsDialog:(UIWindow *)targetWindow;
 + (void)getChannelConfig:(void(^)(NSDictionary *))callback;
 + (void)getSubscriptionId:(void(^)(NSString *))callback;

--- a/CleverPush/CleverPush/Source/CleverPush.m
+++ b/CleverPush/CleverPush/Source/CleverPush.m
@@ -73,9 +73,10 @@ static BOOL autoClearBadge = YES;
 static BOOL incrementBadge = NO;
 static BOOL autoRegister = YES;
 static BOOL registrationInProgress = false;
+static const int secDifferenceAtVeryFirstTime = 0;
+static const int validationSeconds = 3600 ;
 
 static NSString* channelId;
-
 static NSString* lastNotificationReceivedId;
 static NSString* lastNotificationOpenedId;
 static NSDictionary* channelConfig;
@@ -2311,14 +2312,22 @@ static id isNil(id object) {
 
 + (void)showTopicDialogOnNewAdded {
     [self getChannelConfig:^(NSDictionary* channelConfig) {
-        NSInteger seconds = [CPUtils secondsBetweenDate:[CPUtils getLastTimeAutomaticallyShowed] andDate:[NSDate date]];
-        if ([CPUtils newTopicAdded:channelConfig] && (seconds == 0 || seconds > 3600)) {
+        if ([self hasNewTopicAfterOneHour:channelConfig initialDifference:secDifferenceAtVeryFirstTime displayDialogDifference:validationSeconds]) {
             [self showTopicsDialog];
             [CPUtils updateLastTimeAutomaticallyShowed];
         } else {
             [self showPendingTopicsDialog];
         }
     }];
+}
+
++ (BOOL)hasNewTopicAfterOneHour:(NSDictionary*)config initialDifference:(NSInteger)initialDifference displayDialogDifference:(NSInteger)displayAfter {
+    NSInteger secondsAfterLastCheck = [CPUtils secondsBetweenDate:[CPUtils getLastTimeAutomaticallyShowed] andDate:[NSDate date]];
+    if ([CPUtils newTopicAdded:config] && (secondsAfterLastCheck == initialDifference || secondsAfterLastCheck > displayAfter)) {
+        return YES;
+    } else {
+        return NO;
+    }
 }
 
 + (void)showTopicsDialog:(UIWindow *)targetWindow {

--- a/CleverPush/CleverPush/Source/CleverPush.m
+++ b/CleverPush/CleverPush/Source/CleverPush.m
@@ -451,7 +451,7 @@ static id isNil(id object) {
 #pragma mark - Initialised Features.
 + (void)initFeatures {
     dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
-        [self showPendingTopicsDialog];
+        [self showTopicDialogOnNewAdded];
         [self initAppReview];
         
         [CPAppBannerModule initBannersWithChannel:channelId showDrafts:developmentMode fromNotification:NO];
@@ -2307,6 +2307,18 @@ static id isNil(id object) {
         [self showTopicsDialog:topicsDialogWindow];
     }
     [self showTopicsDialog:[self keyWindow]];
+}
+
++ (void)showTopicDialogOnNewAdded {
+    [self getChannelConfig:^(NSDictionary* channelConfig) {
+        NSInteger seconds = [CPUtils secondsBetweenDate:[CPUtils getLastTimeAutomaticallyShowed] andDate:[NSDate date]];
+        if ([CPUtils newTopicAdded:channelConfig] && (seconds == 0 || seconds > 3600)) {
+            [self showTopicsDialog];
+            [CPUtils updateLastTimeAutomaticallyShowed];
+        } else {
+            [self showPendingTopicsDialog];
+        }
+    }];
 }
 
 + (void)showTopicsDialog:(UIWindow *)targetWindow {


### PR DESCRIPTION
Automatically present topic dialog.
if the new topic has been added to the list of topics from the cleverpush developer console.
file changes:
`CleverPush.h`, `CleverPush.m`, `CPTopicsViewController.m`, `CPUtils.h` & `CPUtils.m`
- added methods on `CleverPush.h`
`showTopicDialogOnNewAdded` 
- rename two methods in `CPUtils`
`updateLastTopicCheckedTime`
`getLastTopicCheckedTime`
- added five new methods in `CPUtils`
`updateLastTimeAutomaticallyShowed`
`getLastTimeAutomaticallyShowed`
`newTopicAdded`
`getLocalDateTimeFromUTC`
`secondsBetweenDate`