### PR TITLE
hotfix/5668-iphone-migrated-to-new-iphone-no-more-pushes-received

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -384,6 +384,9 @@ static id isNil(id object) {
                 [CPLog debug:@"syncSubscription called from initWithChannelId"];
                 [self performSelector:@selector(syncSubscription) withObject:nil afterDelay:10.0f];
             } else {
+                [self ensureMainThreadSync:^{
+                           [[UIApplication sharedApplication] registerForRemoteNotifications];
+                       }];
                 if ([self getSubscribeHandler] && ![self getHandleSubscribedCalled]) {
                     [self getSubscribeHandler](subscriptionId);
                     [self setHandleSubscribedCalled:YES];

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -385,8 +385,9 @@ static id isNil(id object) {
                 [self performSelector:@selector(syncSubscription) withObject:nil afterDelay:10.0f];
             } else {
                 [self ensureMainThreadSync:^{
-                           [[UIApplication sharedApplication] registerForRemoteNotifications];
-                       }];
+                    [[UIApplication sharedApplication] registerForRemoteNotifications];
+                }];
+
                 if ([self getSubscribeHandler] && ![self getHandleSubscribedCalled]) {
                     [self getSubscribeHandler](subscriptionId);
                     [self setHandleSubscribedCalled:YES];


### PR DESCRIPTION
method changes for getting the updated device token.