### PR TITLE
hotfix/CP-5908-getting-nil-for-banner-description-property

### DIFF
--- a/CleverPush/Source/CPAppBanner.m
+++ b/CleverPush/Source/CPAppBanner.m
@@ -21,7 +21,7 @@
         self.toVersion = [json cleverPushStringForKey:@"toVersion"];
 
         self.title = [json cleverPushStringForKey:@"title"];
-        self.bannerDescription = [json cleverPushStringForKey:@"bannerDescription"];
+        self.bannerDescription = [json cleverPushStringForKey:@"description"];
         self.mediaUrl = [json cleverPushStringForKey:@"mediaUrl"];
 
         if ([json cleverPushStringForKey:@"testId"] != nil) {


### PR DESCRIPTION
App banner description and key parameter changes.