### PR TITLE
hotfix/CP-5955-ios-app-banner-carousel-crash

### DIFF
--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -44,7 +44,11 @@
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return [self.blocks count];
+    if (self.blocks.count == 0 || self.blocks == nil ) {
+        return 0;
+    } else {
+        return self.blocks.count;
+    }
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -44,11 +44,10 @@
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    if (self.blocks.count == 0 || self.blocks == nil ) {
+    if (self.blocks == nil) {
         return 0;
-    } else {
-        return self.blocks.count;
     }
+    return self.blocks.count;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -44,7 +44,7 @@
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    if (self.blocks == nil) {
+    if (self.blocks == nil || self.blocks.count == 0) {
         return 0;
     }
     return self.blocks.count;

--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -173,7 +173,11 @@ CPNotificationClickBlock handleClick;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return self.notifications.count;
+    if (self.notifications.count == 0 || self.notifications == nil ) {
+        return 0;
+    } else {
+        return self.notifications.count;
+    }
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -173,11 +173,10 @@ CPNotificationClickBlock handleClick;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    if (self.notifications.count == 0 || self.notifications == nil ) {
+    if (self.notifications == nil) {
         return 0;
-    } else {
-        return self.notifications.count;
     }
+    return self.notifications.count;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -173,7 +173,7 @@ CPNotificationClickBlock handleClick;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    if (self.notifications == nil) {
+    if (self.notifications == nil || self.notifications.count == 0) {
         return 0;
     }
     return self.notifications.count;


### PR DESCRIPTION
changed the array return method for code optimisation.