### PR TITLE
hotfix/CP-6843-ios-app-banner-too-long-button-text-should-go-into-next-line

### DIFF
--- a/CleverPush/Resources/CPButtonBlockCell.xib
+++ b/CleverPush/Resources/CPButtonBlockCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21179.7" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment version="2304" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21169.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,6 +20,9 @@
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4hC-1g-8za" customClass="CPUIBlockButton">
                         <rect key="frame" x="10" y="0.0" width="396" height="48"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="48" id="J5f-NH-1Sw"/>
+                        </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="72"/>
                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                         <state key="normal" title="button"/>
@@ -37,6 +40,7 @@
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <connections>
                 <outlet property="btnCPBanner" destination="4hC-1g-8za" id="zVv-Jt-Ijs"/>
+                <outlet property="btnCPBannerHeightConstraint" destination="J5f-NH-1Sw" id="j4y-FH-YJQ"/>
             </connections>
             <point key="canvasLocation" x="201.44927536231884" y="86.71875"/>
         </tableViewCell>

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -112,10 +112,12 @@
         CPButtonBlockCell *cell = [tableView dequeueReusableCellWithIdentifier:@"CPButtonBlockCell" forIndexPath:indexPath];
 
         CPAppBannerButtonBlock *block = (CPAppBannerButtonBlock*)self.blocks[indexPath.row];
+        NSString *buttonText = block.text;
 
-        [cell.btnCPBanner setTitle:block.text forState:UIControlStateNormal];
+        [cell.btnCPBanner setTitle:buttonText forState:UIControlStateNormal];
         if (self.voucherCode != nil && ![self.voucherCode isKindOfClass:[NSNull class]] && ![self.voucherCode isEqualToString:@""]) {
-            [cell.btnCPBanner setTitle:[CPUtils replaceString:@"{voucherCode}" withReplacement:self.voucherCode inString:block.text] forState:UIControlStateNormal];
+            buttonText = [CPUtils replaceString:@"{voucherCode}" withReplacement:self.voucherCode inString:block.text];
+            [cell.btnCPBanner setTitle:buttonText forState:UIControlStateNormal];
         }
 
         UIColor *titleColor;
@@ -156,10 +158,21 @@
         }
         cell.btnCPBanner.backgroundColor = backgroundColor;
 
+        CGSize maxSize = CGSizeMake(cell.btnCPBanner.frame.size.width - (15.0 * 2), CGFLOAT_MAX);
+        CGRect titleRect = [buttonText boundingRectWithSize:maxSize
+                                                     options:NSStringDrawingUsesLineFragmentOrigin
+                                                  attributes:@{NSFontAttributeName: cell.btnCPBanner.titleLabel.font}
+                                                     context:nil];
+        CGFloat titleHeight = ceil(titleRect.size.height);
+        titleHeight = titleHeight + 10;
+
         cell.btnCPBanner.contentEdgeInsets = UIEdgeInsetsMake(15.0, 15.0, 15.0, 15.0);
         cell.btnCPBanner.translatesAutoresizingMaskIntoConstraints = false;
         cell.btnCPBanner.layer.cornerRadius = (CGFloat)block.radius * 0.6;
         cell.btnCPBanner.adjustsImageWhenHighlighted = YES;
+        cell.btnCPBanner.titleLabel.numberOfLines = 0;
+        cell.btnCPBanner.titleLabel.textAlignment = NSTextAlignmentCenter;
+        cell.btnCPBannerHeightConstraint.constant = titleHeight;
         [cell.btnCPBanner setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
 
         [cell.btnCPBanner handleControlEvent:UIControlEventTouchUpInside withBlock:^{

--- a/CleverPush/Source/CPButtonBlockCell.h
+++ b/CleverPush/Source/CPButtonBlockCell.h
@@ -4,6 +4,7 @@
 @interface CPButtonBlockCell : UITableViewCell
 
 @property (weak, nonatomic) IBOutlet CPUIBlockButton *btnCPBanner;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *btnCPBannerHeightConstraint;
 
 @end
 

--- a/CleverPush/Source/CPInboxDetailContainer.m
+++ b/CleverPush/Source/CPInboxDetailContainer.m
@@ -118,10 +118,21 @@
         }
         cell.btnCPBanner.backgroundColor = backgroundColor;
 
+        CGSize maxSize = CGSizeMake(cell.btnCPBanner.frame.size.width - (15.0 * 2), CGFLOAT_MAX);
+        CGRect titleRect = [block.text boundingRectWithSize:maxSize
+                                                     options:NSStringDrawingUsesLineFragmentOrigin
+                                                  attributes:@{NSFontAttributeName: cell.btnCPBanner.titleLabel.font}
+                                                     context:nil];
+        CGFloat titleHeight = ceil(titleRect.size.height);
+        titleHeight = titleHeight + 10;
+
         cell.btnCPBanner.contentEdgeInsets = UIEdgeInsetsMake(15.0, 15.0, 15.0, 15.0);
         cell.btnCPBanner.translatesAutoresizingMaskIntoConstraints = false;
         cell.btnCPBanner.layer.cornerRadius = (CGFloat)block.radius * 0.6;
         cell.btnCPBanner.adjustsImageWhenHighlighted = YES;
+        cell.btnCPBanner.titleLabel.numberOfLines = 0;
+        cell.btnCPBanner.titleLabel.textAlignment = NSTextAlignmentCenter;
+        cell.btnCPBannerHeightConstraint.constant = titleHeight;
         [cell.btnCPBanner setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
 
         [cell.btnCPBanner handleControlEvent:UIControlEventTouchUpInside withBlock:^{


### PR DESCRIPTION


Solved the issue of not displaying the whole text in the button title.