### PR TITLE
hotfix/CP-6838-ios-last-topic-not-fully-visible-in-topics-dialog

### DIFF
--- a/CleverPush/Source/CPTopicsViewController.m
+++ b/CleverPush/Source/CPTopicsViewController.m
@@ -366,6 +366,10 @@ static CGFloat const CPConstraints = 30.0;
     cell.titleText.tag = 200;
     cell.titleText.backgroundColor = [UIColor clearColor];
     cell.accessibilityLabel = cell.titleText.text;
+    [UIView performWithoutAnimation:^{
+        [tableView beginUpdates];
+        [tableView endUpdates];
+    }];
     return cell;
 }
 


### PR DESCRIPTION
Solved the issue of the last topic not being fully visible in the topic dialogue.