### PR TITLE
hotfix/CP-6887-ios-app-banner-crash-with-multiple-screens-carousel

### DIFF
--- a/CleverPush/Source/CPAppBannerCarouselBlock.h
+++ b/CleverPush/Source/CPAppBannerCarouselBlock.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "CPAppBannerBlock.h"
+#import "CPAppBannerBackground.h"
 
 @interface CPAppBannerCarouselBlock : NSObject
 
@@ -8,6 +9,7 @@
 @property (nonatomic, strong) NSMutableArray<CPAppBannerBlock*> *blocks;
 @property (assign) BOOL isScreenClicked;
 @property (assign) BOOL isScreenAlreadyShown;
+@property (nonatomic, strong) CPAppBannerBackground *background;
 
 - (id)initWithJson:(NSDictionary*)json;
 

--- a/CleverPush/Source/CPAppBannerCarouselBlock.m
+++ b/CleverPush/Source/CPAppBannerCarouselBlock.m
@@ -43,6 +43,10 @@
                 [self.blocks addObject:block];
             }
         }
+
+        if ([json objectForKey:@"background"] != nil) {
+            self.background = [[CPAppBannerBackground alloc] initWithJson:[json objectForKey:@"background"]];
+        }
     }
     return self;
 }

--- a/CleverPush/Source/CPAppBannerViewController.m
+++ b/CleverPush/Source/CPAppBannerViewController.m
@@ -193,10 +193,17 @@
 
 #pragma mark - Set background color
 - (void)setBackgroundColor {
-    [self.view setBackgroundColor:[UIColor whiteColor]];
-
-    if (self.data.background.color != nil && ![self.data.background.color isKindOfClass:[NSNull class]] && ![self.data.background.color isEqualToString:@""] ) {
-        [self.view setBackgroundColor:[UIColor colorWithHexString:self.data.background.color]];
+    if (self.data.carouselEnabled || self.data.multipleScreensEnabled) {
+        if (self.data.screens[self.index].background != nil && ![self.data.screens[self.index].background isKindOfClass:[NSNull class]] && self.data.screens[self.index].background.color != nil && ![self.data.screens[self.index].background.color isKindOfClass:[NSNull class]] && ![self.data.screens[self.index].background.color isEqualToString:@""]) {
+            [self.view setBackgroundColor:[UIColor colorWithHexString:self.data.screens[self.index].background.color]];
+        } else {
+            [self.view setBackgroundColor:[UIColor whiteColor]];
+        }
+    } else {
+        [self.view setBackgroundColor:[UIColor whiteColor]];
+        if (self.data.background.color != nil && ![self.data.background.color isKindOfClass:[NSNull class]] && ![self.data.background.color isEqualToString:@""] ) {
+            [self.view setBackgroundColor:[UIColor colorWithHexString:self.data.background.color]];
+        }
     }
 }
 

--- a/CleverPush/Source/CPBannerCardContainer.h
+++ b/CleverPush/Source/CPBannerCardContainer.h
@@ -31,6 +31,7 @@
 @property (nonatomic, weak) id <HeightDelegate> delegate;
 @property (nonatomic, weak) id <NavigateNextPage> changePage;
 @property (nonatomic, assign) NSString *voucherCode;
+@property (nonatomic) NSInteger currentScreenIndex;
 
 - (void)setActionCallback:(CPAppBannerActionBlock)callback;
 - (void)setDynamicCloseButton:(BOOL)closeButtonEnabled;

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -60,6 +60,8 @@
     NSDictionary *pagevalue = notification.userInfo;
     NSInteger index = [pagevalue[@"currentIndex"] integerValue];
     self.pageControl.currentPage = index;
+    self.currentScreenIndex = index;
+    [self setBackground];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
@@ -352,7 +354,15 @@
         return;
     }
 
-    [self.imgviewBackground setBackgroundColor:[UIColor colorWithHexString:self.data.background.color]];
+    if (self.data.carouselEnabled || self.data.multipleScreensEnabled) {
+        if (self.data.screens[self.currentScreenIndex].background != nil && ![self.data.screens[self.currentScreenIndex].background isKindOfClass:[NSNull class]] && self.data.screens[self.currentScreenIndex].background.color != nil && ![self.data.screens[self.currentScreenIndex].background.color isKindOfClass:[NSNull class]] && ![self.data.screens[self.currentScreenIndex].background.color isEqualToString:@""]) {
+            [self.imgviewBackground setBackgroundColor:[UIColor colorWithHexString:self.data.screens[self.currentScreenIndex].background.color]];
+        } else {
+            [self.imgviewBackground setBackgroundColor:[UIColor whiteColor]];
+        }
+    } else {
+        [self.imgviewBackground setBackgroundColor:[UIColor colorWithHexString:self.data.background.color]];
+    }
 }
 
 - (void)setUpPageControl {
@@ -372,9 +382,17 @@
     [self.contentView setBackgroundColor:[UIColor clearColor]];
 
     if (self.data.type == CPAppBannerTypeFull) {
-        [self.contentView setBackgroundColor:[UIColor whiteColor]];
-        if (self.data.background.color != nil && ![self.data.background.color isKindOfClass:[NSNull class]] && ![self.data.background.color isEqualToString:@""] ) {
-            [self.contentView setBackgroundColor:[UIColor colorWithHexString:self.data.background.color]];
+        if (self.data.carouselEnabled || self.data.multipleScreensEnabled) {
+            if (self.data.screens[self.currentScreenIndex].background != nil && ![self.data.screens[self.currentScreenIndex].background isKindOfClass:[NSNull class]] && self.data.screens[self.currentScreenIndex].background.color != nil && ![self.data.screens[self.currentScreenIndex].background.color isKindOfClass:[NSNull class]] && ![self.data.screens[self.currentScreenIndex].background.color isEqualToString:@""]) {
+                [self.contentView setBackgroundColor:[UIColor colorWithHexString:self.data.screens[self.currentScreenIndex].background.color]];
+            } else {
+                [self.contentView setBackgroundColor:[UIColor whiteColor]];
+            }
+        } else {
+            [self.contentView setBackgroundColor:[UIColor whiteColor]];
+            if (self.data.background.color != nil && ![self.data.background.color isKindOfClass:[NSNull class]] && ![self.data.background.color isEqualToString:@""] ) {
+                [self.contentView setBackgroundColor:[UIColor colorWithHexString:self.data.background.color]];
+            }
         }
     }
 }

--- a/CleverPush/Source/CPInboxDetailView.m
+++ b/CleverPush/Source/CPInboxDetailView.m
@@ -69,7 +69,15 @@
         return;
     }
 
-    [self.backGroundImage setBackgroundColor:[UIColor colorWithHexString:self.data.background.color]];
+    if (self.data.carouselEnabled || self.data.multipleScreensEnabled) {
+        if (self.data.screens[self.index].background != nil && ![self.data.screens[self.index].background isKindOfClass:[NSNull class]] && self.data.screens[self.index].background.color != nil && ![self.data.screens[self.index].background.color isKindOfClass:[NSNull class]] && ![self.data.screens[self.index].background.color isEqualToString:@""]) {
+            [self.backGroundImage setBackgroundColor:[UIColor colorWithHexString:self.data.screens[self.index].background.color]];
+        } else {
+            [self.backGroundImage setBackgroundColor:[UIColor whiteColor]];
+        }
+    } else {
+        [self.backGroundImage setBackgroundColor:[UIColor colorWithHexString:self.data.background.color]];
+    }
 }
 
 #pragma mark - dynamic hide and show top button from top right corner


### PR DESCRIPTION
Solved a crash issue where the background colour was not applying while multiple screens and a carousel were enabled.