### PR TITLE
feature/CP-7390-app-banners-always-save-shown-banners-ios

### DIFF
--- a/CleverPush/Source/CPAppBannerAction.m
+++ b/CleverPush/Source/CPAppBannerAction.m
@@ -8,7 +8,7 @@
     self.blockId = @"";
     if (self && json && ![json isKindOfClass:[NSNull class]]) {
         if ([json objectForKey:@"url"] && [[json objectForKey:@"url"] isKindOfClass:[NSString class]]) {
-            self.url= [NSURL URLWithString:[[json objectForKey:@"url"] stringByAddingPercentEscapesUsingEncoding:
+            self.url = [NSURL URLWithString:[[json objectForKey:@"url"] stringByAddingPercentEscapesUsingEncoding:
                                                         NSUTF8StringEncoding]];
         }
         

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -907,9 +907,7 @@ NSInteger currentScreenIndex = 0;
         };
         [appBannerViewController setActionCallback:callbackBlock];
 
-        if (banner.frequency == CPAppBannerFrequencyOnce) {
-            [self setBannerIsShown:banner];
-        }
+        [self setBannerIsShown:banner];
 
         // remove banner so it will not show again this session
         if (currentEventId == nil || [currentEventId isKindOfClass:[NSNull class]] || [currentEventId isEqualToString:@""] || banner.frequency != CPAppBannerFrequencyEveryTrigger) {


### PR DESCRIPTION
Optimized the `showBanner` method for saving banner IDs in preferences always.