### PR TITLE
hotfix/CP-7439-ios-sdk-add-silent-field-in-the-notification-payload-model

### DIFF
--- a/CleverPush/Source/CPNotification.m
+++ b/CleverPush/Source/CPNotification.m
@@ -100,6 +100,11 @@
     } else {
         self.customData = [[NSDictionary alloc] init];
     }
+
+    self.silent = NO;
+    if ([json objectForKey:@"silent"] && [json objectForKey:@"silent"] != nil && ![[json objectForKey:@"silent"] isKindOfClass:[NSNull class]]) {
+        self.silent = [[json objectForKey:@"silent"] boolValue];
+    }
 }
 
 @end


### PR DESCRIPTION
Added a `silent` field in the notification payload model