### PR TITLE
feature/CP-7433-ios-get-badge-count-set-badge-count-methods

### DIFF
--- a/CleverPush/Source/CleverPush.h
+++ b/CleverPush/Source/CleverPush.h
@@ -153,6 +153,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 + (void)setAuthorizerToken:(NSString* _Nullable)authorizerToken;
 + (void)setCustomTopViewController:(UIViewController* _Nullable)viewController;
 + (void)setLocalEventTrackingRetentionDays:(int)days;
++ (void)setBadgeCount:(NSInteger)count;
 + (void)updateBadge:(UNMutableNotificationContent* _Nullable)replacementContent API_AVAILABLE(ios(10.0));
 + (void)addStoryView:(CPStoryView* _Nullable)storyView;
 + (void)updateDeselectFlag:(BOOL)value;
@@ -180,6 +181,8 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 + (NSString* _Nullable)channelId;
 + (UIViewController* _Nullable)getCustomTopViewController;
 + (int)getLocalEventTrackingRetentionDays;
++ (NSInteger)getBadgeCount;
++ (void)getBadgeCountWithCompletion:(void (^ _Nullable)(NSInteger))completion;
 + (CPIabTcfMode)getIabTcfMode;
 
 + (UIColor* _Nullable)getBrandingColor;

--- a/CleverPush/Source/CleverPush.h
+++ b/CleverPush/Source/CleverPush.h
@@ -181,7 +181,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 + (NSString* _Nullable)channelId;
 + (UIViewController* _Nullable)getCustomTopViewController;
 + (int)getLocalEventTrackingRetentionDays;
-+ (void)getBadgeCountWithCompletionHandler:(void (^)(NSInteger))completionHandler;
++ (void)getBadgeCountWithCompletionHandler:(void (^ _Nullable)(NSInteger))completionHandler;
 + (CPIabTcfMode)getIabTcfMode;
 
 + (UIColor* _Nullable)getBrandingColor;

--- a/CleverPush/Source/CleverPush.h
+++ b/CleverPush/Source/CleverPush.h
@@ -181,8 +181,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 + (NSString* _Nullable)channelId;
 + (UIViewController* _Nullable)getCustomTopViewController;
 + (int)getLocalEventTrackingRetentionDays;
-+ (NSInteger)getBadgeCount;
-+ (void)getBadgeCountWithCompletion:(void (^ _Nullable)(NSInteger))completion;
++ (void)getBadgeCountWithCompletionHandler:(void (^)(NSInteger))completionHandler;
 + (CPIabTcfMode)getIabTcfMode;
 
 + (UIColor* _Nullable)getBrandingColor;

--- a/CleverPush/Source/CleverPush.m
+++ b/CleverPush/Source/CleverPush.m
@@ -526,6 +526,10 @@ static CleverPush* singleInstance = nil;
     [self.CPSharedInstance setLocalEventTrackingRetentionDays:days];
 }
 
++ (void)setBadgeCount:(NSInteger)count {
+    [self.CPSharedInstance setBadgeCount:count];
+}
+
 + (void)updateBadge:(UNMutableNotificationContent* _Nullable)replacementContent API_AVAILABLE(ios(10.0)) {
     [self.CPSharedInstance updateBadge:replacementContent];
 }
@@ -620,6 +624,14 @@ static CleverPush* singleInstance = nil;
 
 + (int)getLocalEventTrackingRetentionDays {
     return [self.CPSharedInstance getLocalEventTrackingRetentionDays];
+}
+
++ (NSInteger)getBadgeCount{
+    return [self.CPSharedInstance getBadgeCount];
+}
+
++ (void)getBadgeCountWithCompletion:(void (^)(NSInteger))completion {
+    [self.CPSharedInstance getBadgeCountWithCompletion:completion];
 }
 
 + (NSString* _Nullable)channelId {

--- a/CleverPush/Source/CleverPush.m
+++ b/CleverPush/Source/CleverPush.m
@@ -626,7 +626,7 @@ static CleverPush* singleInstance = nil;
     return [self.CPSharedInstance getLocalEventTrackingRetentionDays];
 }
 
-+ (void)getBadgeCountWithCompletionHandler:(void (^)(NSInteger))completionHandler {
++ (void)getBadgeCountWithCompletionHandler:(void (^ _Nullable)(NSInteger))completionHandler {
     return [self.CPSharedInstance getBadgeCountWithCompletionHandler:completionHandler];
 }
 

--- a/CleverPush/Source/CleverPush.m
+++ b/CleverPush/Source/CleverPush.m
@@ -626,12 +626,8 @@ static CleverPush* singleInstance = nil;
     return [self.CPSharedInstance getLocalEventTrackingRetentionDays];
 }
 
-+ (NSInteger)getBadgeCount{
-    return [self.CPSharedInstance getBadgeCount];
-}
-
-+ (void)getBadgeCountWithCompletion:(void (^)(NSInteger))completion {
-    [self.CPSharedInstance getBadgeCountWithCompletion:completion];
++ (void)getBadgeCountWithCompletionHandler:(void (^)(NSInteger))completionHandler {
+    return [self.CPSharedInstance getBadgeCountWithCompletionHandler:completionHandler];
 }
 
 + (NSString* _Nullable)channelId {

--- a/CleverPush/Source/CleverPushInstance.h
+++ b/CleverPush/Source/CleverPushInstance.h
@@ -210,8 +210,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 - (NSString* _Nullable)channelId;
 - (UIViewController* _Nullable)getCustomTopViewController;
 - (int)getLocalEventTrackingRetentionDays;
-- (NSInteger)getBadgeCount;
-- (void)getBadgeCountWithCompletion:(void (^ _Nullable)(NSInteger))completion;
+- (void)getBadgeCountWithCompletionHandler:(void (^)(NSInteger))completionHandler;
 - (CPIabTcfMode)getIabTcfMode;
 
 - (UIColor* _Nullable)getBrandingColor;

--- a/CleverPush/Source/CleverPushInstance.h
+++ b/CleverPush/Source/CleverPushInstance.h
@@ -210,7 +210,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 - (NSString* _Nullable)channelId;
 - (UIViewController* _Nullable)getCustomTopViewController;
 - (int)getLocalEventTrackingRetentionDays;
-- (void)getBadgeCountWithCompletionHandler:(void (^)(NSInteger))completionHandler;
+- (void)getBadgeCountWithCompletionHandler:(void (^ _Nullable)(NSInteger))completionHandler;
 - (CPIabTcfMode)getIabTcfMode;
 
 - (UIColor* _Nullable)getBrandingColor;

--- a/CleverPush/Source/CleverPushInstance.h
+++ b/CleverPush/Source/CleverPushInstance.h
@@ -185,6 +185,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 - (void)setAuthorizerToken:(NSString* _Nullable)authorizerToken;
 - (void)setCustomTopViewController:(UIViewController* _Nullable)viewController;
 - (void)setLocalEventTrackingRetentionDays:(int)days;
+- (void)setBadgeCount:(NSInteger)count;
 - (void)updateBadge:(UNMutableNotificationContent* _Nullable)replacementContent API_AVAILABLE(ios(10.0));
 - (void)addStoryView:(CPStoryView* _Nullable)storyView;
 - (void)updateDeselectFlag:(BOOL)value;
@@ -209,6 +210,8 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 - (NSString* _Nullable)channelId;
 - (UIViewController* _Nullable)getCustomTopViewController;
 - (int)getLocalEventTrackingRetentionDays;
+- (NSInteger)getBadgeCount;
+- (void)getBadgeCountWithCompletion:(void (^ _Nullable)(NSInteger))completion;
 - (CPIabTcfMode)getIabTcfMode;
 
 - (UIColor* _Nullable)getBrandingColor;

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -97,7 +97,6 @@ int maximumNotifications = 100;
 int iabtcfVendorConsentPosition = 1139;
 static UIViewController*customTopViewController = nil;
 int localEventTrackingRetentionDays = 90;
-static NSInteger badgeCount = 0;
 
 static NSString* channelId;
 static NSString* lastNotificationReceivedId;
@@ -3586,7 +3585,7 @@ static id isNil(id object) {
     localEventTrackingRetentionDays = days;
 }
 
-+ (void)setBadgeCount:(NSInteger)count {
+- (void)setBadgeCount:(NSInteger)count {
     if (@available(iOS 16, *)) {
         [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:count withCompletionHandler:nil];
     } else {
@@ -3614,7 +3613,7 @@ static id isNil(id object) {
     return localEventTrackingRetentionDays;
 }
 
-- (void)getBadgeCountWithCompletionHandler:(void (^)(NSInteger))completionHandler {
+- (void)getBadgeCountWithCompletionHandler:(void (^ _Nullable)(NSInteger))completionHandler {
     [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
         NSInteger badgeCount = [notifications count];
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -97,6 +97,7 @@ int maximumNotifications = 100;
 int iabtcfVendorConsentPosition = 1139;
 static UIViewController*customTopViewController = nil;
 int localEventTrackingRetentionDays = 90;
+NSInteger badgeCount = 0;
 
 static NSString* channelId;
 static NSString* lastNotificationReceivedId;
@@ -3581,6 +3582,10 @@ static id isNil(id object) {
     localEventTrackingRetentionDays = days;
 }
 
+- (void)setBadgeCount:(NSInteger)count {
+    badgeCount = count;
+}
+
 - (NSString* _Nullable)getApiEndpoint {
     return apiEndpoint;
 }
@@ -3599,6 +3604,16 @@ static id isNil(id object) {
 
 - (int)getLocalEventTrackingRetentionDays {
     return localEventTrackingRetentionDays;
+}
+
+- (NSInteger)getBadgeCount {
+    return badgeCount;
+}
+
+- (void)getBadgeCountWithCompletion:(void (^)(NSInteger))completion {
+    [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> *notifications) {
+        completion([self getBadgeCount]);
+    }];
 }
 
 #pragma mark - App Banner methods

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -3586,8 +3586,7 @@ static id isNil(id object) {
     localEventTrackingRetentionDays = days;
 }
 
-- (void)setBadgeCount:(NSInteger)count {
-    badgeCount = count;
++ (void)setBadgeCount:(NSInteger)count {
     if (@available(iOS 16, *)) {
         [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:count withCompletionHandler:nil];
     } else {
@@ -3617,6 +3616,7 @@ static id isNil(id object) {
 
 - (void)getBadgeCountWithCompletionHandler:(void (^)(NSInteger))completionHandler {
     [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
+        NSInteger badgeCount = [notifications count];
         dispatch_async(dispatch_get_main_queue(), ^{
             completionHandler(badgeCount);
         });

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1824,7 +1824,7 @@ static id isNil(id object) {
         } else {
             [UNUserNotificationCenter.currentNotificationCenter getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification*>*notifications) {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    if (@available(iOS 17.0, *)) {
+                    if (@available(iOS 16.0, *)) {
                         [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:[notifications count] withCompletionHandler:nil];
                     } else {
                         [[UIApplication sharedApplication] setApplicationIconBadgeNumber:[notifications count]];
@@ -3586,7 +3586,7 @@ static id isNil(id object) {
 }
 
 - (void)setBadgeCount:(NSInteger)count {
-    if (@available(iOS 16, *)) {
+    if (@available(iOS 16.0, *)) {
         [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:count withCompletionHandler:nil];
     } else {
         [UIApplication sharedApplication].applicationIconBadgeNumber = count;


### PR DESCRIPTION
implementing `setBadgeCount` and `getBadgeCount` methods for updating the notification badge count.