### PR TITLE
hotfix/CP-7514-ios-sdk-app-banner-always-displayed-banner-targeting-not-working-from-test-push

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -3678,7 +3678,7 @@ static id isNil(id object) {
 - (void)showAppBanner:(NSString*)bannerId channelId:(NSString*)channelId notificationId:(NSString*)notificationId {
     BOOL fromNotification = notificationId != nil;
     [CPAppBannerModule initBannersWithChannel:channelId showDrafts:isShowDraft fromNotification:fromNotification];
-    [CPAppBannerModule showBanner:channelId bannerId:bannerId notificationId:notificationId force:true];
+    [CPAppBannerModule showBanner:channelId bannerId:bannerId notificationId:notificationId force:NO];
 }
 
 - (void)setAppBannerOpenedCallback:(CPAppBannerActionBlock _Nullable)callback {

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -3710,7 +3710,7 @@ static id isNil(id object) {
 }
 
 - (void)showAppBanner:(NSString*)bannerId notificationId:(NSString*)notificationId {
-    [CPAppBannerModule showBanner:channelId bannerId:bannerId notificationId:notificationId force:true];
+    [CPAppBannerModule showBanner:channelId bannerId:bannerId notificationId:notificationId force:YES];
 }
 
 - (void)showAppBanner:(NSString*)bannerId channelId:(NSString*)channelId notificationId:(NSString*)notificationId {


### PR DESCRIPTION
Resolved the issue of app-banner targeting not working from push notifications.