### PR TITLE
hotfix/CP-7518-ios-app-banner-image-resizing-when-sliding-back-to-screen-1-after-screen-2

### DIFF
--- a/CleverPush/Resources/CPImageBlockCell.xib
+++ b/CleverPush/Resources/CPImageBlockCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment version="2304" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,7 +21,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="85"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="320" id="30E-TR-UgR"/>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="250" constant="320" id="30E-TR-UgR"/>
                             <constraint firstAttribute="height" relation="lessThanOrEqual" constant="85" id="Jxa-qH-xlF"/>
                         </constraints>
                     </imageView>
@@ -37,11 +37,12 @@
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstItem="oHI-Bb-wQA" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="0cY-bl-Yrv"/>
+                    <constraint firstItem="oHI-Bb-wQA" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="dTV-5E-aZc"/>
                     <constraint firstItem="nUy-yX-FIS" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="kQY-0B-vax"/>
                     <constraint firstItem="nUy-yX-FIS" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="qef-BI-bfw"/>
                     <constraint firstAttribute="bottom" secondItem="oHI-Bb-wQA" secondAttribute="bottom" constant="15" id="uCO-dt-rS3"/>
-                    <constraint firstItem="oHI-Bb-wQA" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="ulc-VF-2ht"/>
-                    <constraint firstAttribute="trailing" secondItem="oHI-Bb-wQA" secondAttribute="trailing" id="xMf-64-Lal"/>
+                    <constraint firstItem="oHI-Bb-wQA" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="H2p-sc-9uM" secondAttribute="leading" id="ulc-VF-2ht"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="oHI-Bb-wQA" secondAttribute="trailing" id="xMf-64-Lal"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="zys-uB-d55"/>

--- a/CleverPush/Source/CPAppBannerViewController.m
+++ b/CleverPush/Source/CPAppBannerViewController.m
@@ -315,6 +315,7 @@
 
 - (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath{
     [((CPBannerCardContainer *)cell).tblCPBanner reloadData];
+    [cell setNeedsLayout];
     [cell layoutIfNeeded];
 }
 

--- a/CleverPush/Source/CPAspectKeepImageView.m
+++ b/CleverPush/Source/CPAspectKeepImageView.m
@@ -183,16 +183,26 @@ static char kCPSessionDataTaskKey;
     if (imageSource) {
         size_t frameCount = CGImageSourceGetCount(imageSource);
         NSMutableArray<UIImage *> *frames = [NSMutableArray arrayWithCapacity:frameCount];
+        NSTimeInterval totalDuration = 0.0;
+
         for (size_t i = 0; i < frameCount; i++) {
             CGImageRef frameImageRef = CGImageSourceCreateImageAtIndex(imageSource, i, NULL);
             if (frameImageRef) {
                 UIImage *frameImage = [UIImage imageWithCGImage:frameImageRef];
                 [frames addObject:frameImage];
+
+                NSDictionary *frameProperties = (__bridge_transfer NSDictionary *)CGImageSourceCopyPropertiesAtIndex(imageSource, i, nil);
+                NSDictionary *gifProperties = frameProperties[(NSString *)kCGImagePropertyGIFDictionary];
+                NSNumber *delayTime = gifProperties[(NSString *)kCGImagePropertyGIFDelayTime];
+                totalDuration += [delayTime doubleValue];
+
+                delayTime = @(MAX([delayTime doubleValue] * 0.1, 0.01));
+
                 CGImageRelease(frameImageRef);
             }
         }
 
-        UIImage *gifImage = [UIImage animatedImageWithImages:frames duration:0.0];
+        UIImage *gifImage = [UIImage animatedImageWithImages:frames duration:totalDuration];
         CFRelease(imageSource);
         return gifImage;
     }

--- a/CleverPush/Source/CPAspectKeepImageView.m
+++ b/CleverPush/Source/CPAspectKeepImageView.m
@@ -195,7 +195,6 @@ static char kCPSessionDataTaskKey;
                 NSDictionary *gifProperties = frameProperties[(NSString *)kCGImagePropertyGIFDictionary];
                 NSNumber *delayTime = gifProperties[(NSString *)kCGImagePropertyGIFDelayTime];
                 totalDuration += [delayTime doubleValue];
-
                 delayTime = @(MAX([delayTime doubleValue] * 0.1, 0.01));
 
                 CGImageRelease(frameImageRef);

--- a/CleverPush/Source/CPInboxDetailView.m
+++ b/CleverPush/Source/CPInboxDetailView.m
@@ -158,12 +158,14 @@
     cell.changePage = self;
     cell.controller = self;
     [cell.tblCPBanner reloadData];
+    [cell setNeedsLayout];
     [cell layoutIfNeeded];
     return cell;
 }
 
 - (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath{
     [((CPInboxDetailContainer *)cell).tblCPBanner reloadData];
+    [cell setNeedsLayout];
     [cell layoutIfNeeded];
 }
 


### PR DESCRIPTION
Resolved the image resizing issue in the app banner.