### PR TITLE
hotfix/CP-7539-i-os-cmp-consent-subscribed-handler-issues-v1

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -191,7 +191,7 @@ static id isNil(id object) {
         [self stopCampaigns];
     }
 
-    if ([CleverPush getIabTcfMode] != CPIabTcfModeDisabled && !hasTrackingConsent) {
+    if ([CleverPush getIabTcfMode] != CPIabTcfModeDisabled && !previousTrackingConsent && hasTrackingConsent) {
         pendingTrackingConsentListeners = [NSMutableArray new];
     }
 
@@ -210,10 +210,11 @@ static id isNil(id object) {
 }
 
 - (void)setSubscribeConsent:(BOOL)consent {
+    BOOL previousSubscribeConsent = hasSubscribeConsent;
     hasSubscribeConsentCalled = YES;
     hasSubscribeConsent = consent;
 
-    if ([CleverPush getIabTcfMode] != CPIabTcfModeDisabled && !hasSubscribeConsent) {
+    if ([CleverPush getIabTcfMode] != CPIabTcfModeDisabled && !previousSubscribeConsent && hasSubscribeConsent) {
         pendingSubscribeConsentListeners = [NSMutableArray new];
     }
 


### PR DESCRIPTION
CMP consent subscribers are not working.