### PR TITLE
hotfix/CP-7571-ios-crashes-in-app-v1

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -1269,6 +1269,9 @@ NSInteger currentScreenIndex = 0;
 }
 
 - (NSMutableArray<NSDictionary*>*)getEvents {
+    if (!events) {
+        events = [[NSMutableArray alloc]init];
+    }
     return events;
 }
 

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -635,7 +635,9 @@ NSInteger currentScreenIndex = 0;
 }
 
 - (BOOL)checkEventTriggerCondition:(CPAppBannerTriggerCondition*)condition {
-    for (NSDictionary* triggeredEvent in events) {
+    NSMutableArray<NSDictionary*> *eventsCopy = [events mutableCopy];
+
+    for (NSDictionary* triggeredEvent in eventsCopy) {
         if (![[triggeredEvent cleverPushStringForKey:@"id"] isEqualToString:condition.event]) {
             continue;
         }


### PR DESCRIPTION
Optimized banner objects prevent crashes.