### PR TITLE
feature/CP-7748-app-banner-subscribe-open-apps-notification-settings-if-blocked-already

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -866,18 +866,9 @@ NSInteger currentScreenIndex = 0;
             }
 
             if (action && [action.type isEqualToString:@"subscribe"]) {
-                [CleverPush areNotificationsEnabled:^(BOOL notificationsEnabled) {
-                    if (notificationsEnabled) {
+                [CPUtils handleSubscribeActionWithCallback:^(BOOL success) {
+                    if (success) {
                         [CleverPush subscribe];
-                    } else {
-                        dispatch_async(dispatch_get_main_queue(), ^{
-                            NSURL *url = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
-                            if ([[UIApplication sharedApplication] canOpenURL:url]) {
-                                [[UIApplication sharedApplication] openURL:url
-                                                                   options:@{}
-                                                         completionHandler:nil];
-                            }
-                        });
                     }
                 }];
             }

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -866,7 +866,20 @@ NSInteger currentScreenIndex = 0;
             }
 
             if (action && [action.type isEqualToString:@"subscribe"]) {
-                [CleverPush subscribe];
+                [CleverPush areNotificationsEnabled:^(BOOL notificationsEnabled) {
+                    if (notificationsEnabled) {
+                        [CleverPush subscribe];
+                    } else {
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            NSURL *url = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+                            if ([[UIApplication sharedApplication] canOpenURL:url]) {
+                                [[UIApplication sharedApplication] openURL:url
+                                                                   options:@{}
+                                                         completionHandler:nil];
+                            }
+                        });
+                    }
+                }];
             }
 
             if (action && [action.type isEqualToString:@"addTags"]) {

--- a/CleverPush/Source/CPUtils.h
+++ b/CleverPush/Source/CPUtils.h
@@ -38,6 +38,7 @@
 + (NSArray<NSString *> *)scriptMessageNames;
 + (void)configureWebView:(WKWebView *)webView;
 + (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message;
++ (void)handleSubscribeActionWithCallback:(void (^)(BOOL))callback;
 + (BOOL)isNullOrEmpty:(NSString *)string;
 + (NSURL*)replaceAndEncodeURL:(NSURL *)url withReplacement:(NSString *)replacement;
 + (NSString *)valueForKey:(NSString *)key inDictionary:(NSDictionary *)dictionary;

--- a/CleverPush/Source/CPUtils.m
+++ b/CleverPush/Source/CPUtils.m
@@ -704,7 +704,20 @@ NSString * const localeIdentifier = @"en_US_POSIX";
             UIViewController *topController = [CleverPush topViewController];
             [topController dismissViewControllerAnimated:YES completion:nil];
         } else if ([message.name isEqualToString:@"subscribe"]) {
-            [CleverPush subscribe];
+            [CleverPush areNotificationsEnabled:^(BOOL notificationsEnabled) {
+                if (notificationsEnabled) {
+                    [CleverPush subscribe];
+                } else {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        NSURL *url = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+                        if ([[UIApplication sharedApplication] canOpenURL:url]) {
+                            [[UIApplication sharedApplication] openURL:url
+                                                               options:@{}
+                                                     completionHandler:nil];
+                        }
+                    });
+                }
+            }];
         } else if ([message.name isEqualToString:@"unsubscribe"]) {
             [CleverPush unsubscribe];
         } else if ([message.name isEqualToString:@"trackEvent"]) {


### PR DESCRIPTION
Added a feature in the app banners with subscribe action: if notification permission has been blocked, then notification settings should be redirected.