### PR TITLE
hotfix/7798-ios-sdk-device-restored-from-icloud-backup-is-not-subscribed

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -796,7 +796,7 @@ static id isNil(id object) {
 
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *documentsDirectory = [paths objectAtIndex:0];
-    NSString *filePath = [documentsDirectory stringByAppendingPathComponent:syncFile];
+    NSString *filePath = [documentsDirectory stringByAppendingPathComponent:detectDeviceMigrationFile];
 
     if (![[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
         NSError *error = nil;

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -808,7 +808,13 @@ static id isNil(id object) {
             [CPLog debug:@"Failed to write sync file or Error excluding file from backup: %@", error];
         }
 
-        return NO;
+        [self ensureMainThreadSync:^{
+            [[UIApplication sharedApplication] registerForRemoteNotifications];
+        }];
+
+        return YES;
+    } else {
+        NSLog(@"File exists");
     }
 
     return [nextSync compare:[NSDate date]] == NSOrderedAscending;

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -104,7 +104,7 @@ static NSString* channelId;
 static NSString* lastNotificationReceivedId;
 static NSString* lastNotificationOpenedId;
 static NSString* iabtcfVendorConsents = @"IABTCF_VendorConsents";
-static NSString* syncFile = @"syncFile.txt";
+static NSString* detectDeviceMigrationFile = @"CleverPush_SHOULD_SYNC_FILE.txt";
 static NSDictionary* channelConfig;
 static CleverPushInstance* singleInstance = nil;
 

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -813,8 +813,6 @@ static id isNil(id object) {
         }];
 
         return YES;
-    } else {
-        NSLog(@"File exists");
     }
 
     return [nextSync compare:[NSDate date]] == NSOrderedAscending;

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -792,6 +792,23 @@ static id isNil(id object) {
         nextSync = [lastSync dateByAddingTimeInterval:3*24*60*60]; // 3 days after last sync
     }
     [CPLog info:@"next sync: %@", nextSync];
+
+    // Check if the file exists in the Documents directory
+    NSString *filePath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject stringByAppendingPathComponent:@"CleverPushMigration.txt"];
+    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:filePath];
+
+    if (!fileExists) {
+        [CPLog info:@"CleverPushMigration file does not exist, creating file and forcing sync"];
+
+        // Create the CleverPushMigration file
+        BOOL success = [[NSFileManager defaultManager] createFileAtPath:filePath contents:nil attributes:nil];
+        if (!success) {
+            [CPLog error:@"Failed to create CleverPushMigration file"];
+        }
+
+        [self syncSubscription]; // call a sync method again if the file is missing
+    }
+
     return [nextSync compare:[NSDate date]] == NSOrderedAscending;
 }
 


### PR DESCRIPTION
Write a file -> after migration check -> file does not exist anymore → re-sync in the init method of the SDK(should sync)