### PR TITLE
hotfix/CP-8034-ios-sdk-app-banner-should-not-be-closed-if-we-dont-select-dismiss-on-click-checkbox

### DIFF
--- a/CleverPush/Source/CPAppBannerAction.m
+++ b/CleverPush/Source/CPAppBannerAction.m
@@ -26,7 +26,7 @@
             self.name = [json objectForKey:@"name"];
         }
         
-        self.dismiss = YES;
+        self.dismiss = NO;
         if ([json objectForKey:@"dismiss"]) {
             self.dismiss = [[json objectForKey:@"dismiss"] boolValue];
         }


### PR DESCRIPTION
Resolved issue of app banner should not be closed if we don't select dismiss on the click checkbox.