### PR TITLE
hotfix/CP-8258-ios-sdk-too-many-confirm-alerts-reported-to-our-api

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1365,6 +1365,7 @@ static id isNil(id object) {
     [self setHandleSubscribedCalled:NO];
     [self setSubscriptionId:nil];
     isSessionStartCalled = NO;
+    confirmAlertShown = NO;
 }
 
 #pragma mark - unsubscribe

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1681,7 +1681,7 @@ static id isNil(id object) {
                     [self trackSessionStart];
                 }
 
-                if (![self isConfirmAlertShown]) {
+                if (isSubscriptionChanged && ![self isConfirmAlertShown]) {
                     [self setConfirmAlertShown];
                 }
 


### PR DESCRIPTION
Optimised `setConfirmAlertShown` function.