### PR TITLE
hotfix/CP-8283-ios-auto-resubscribe-not-working-when-app-is-killed-and-restarted

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1611,6 +1611,7 @@ static id isNil(id object) {
     }
 
     if (!deviceToken && !subscriptionId) {
+        [self setSubscriptionInProgress:false];
         if (failureBlock) {
             failureBlock([NSError errorWithDomain:@"com.cleverpush" code:400 userInfo:@{NSLocalizedDescriptionKey:@"No deviceToken or subscriptionId available"}]);
         }


### PR DESCRIPTION
Optimised `makeSyncSubscriptionRequest` function for `setSubscriptionInProgress` .