### PR TITLE
hotfix/CP-8287-ios-sdk-app-banner-filtering-and-targeting-are-not-working-if-the-notification-type-is-silent

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -284,7 +284,7 @@ NSInteger currentScreenIndex = 0;
                 NSMutableArray *objectsToRemove = [[NSMutableArray alloc] init];
 
                 for (NSMutableDictionary *eventsObject in appBanners) {
-                    [self showBanner:channelId bannerId:[eventsObject objectForKey:@"appBanner"] notificationId:[eventsObject objectForKey:@"notificationId"] force:true];
+                    [self showBanner:channelId bannerId:[eventsObject objectForKey:@"appBanner"] notificationId:[eventsObject objectForKey:@"notificationId"] force:NO];
                     [objectsToRemove addObject:eventsObject];
                 }
 

--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -238,7 +238,7 @@ CPNotificationClickBlock handleClick;
 
 #pragma mark - Show app banner using the bannerId
 - (void)showAppBanner:(NSString *)bannerId notificationId:(NSString*)notificationId {
-    [self showBanner:[CleverPush channelId] bannerId:bannerId notificationId:notificationId force:true];
+    [self showBanner:[CleverPush channelId] bannerId:bannerId notificationId:notificationId force:YES];
 }
 
 - (void)presentAppBanner:(CPInboxDetailView*)appBannerViewController  banner:(CPAppBanner*)banner {


### PR DESCRIPTION
Resolved the issue of app banner filtering and targeting not working if the notification type is silent.