### PR TITLE
hotfix/CP-8535-ios-18-beta-crash-in-track-session-end

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -3520,13 +3520,17 @@ static id isNil(id object) {
                     long sessionEndedTimestamp = [[NSDate date] timeIntervalSince1970];
                     long sessionDuration = sessionEndedTimestamp - sessionStartedTimestamp;
 
+                    if (channelId == nil || subscriptionId == nil || deviceToken == nil || sessionVisits < 0 || sessionDuration < 0) {
+                        return;
+                    }
+
                     NSMutableURLRequest* request = [[CleverPushHTTPClient sharedClient] requestWithMethod:HTTP_POST path:@"subscription/session/end"];
                     NSDictionary* dataDic = [NSDictionary dictionaryWithObjectsAndKeys:
                                              channelId, @"channelId",
                                              subscriptionId, @"subscriptionId",
                                              deviceToken, @"apnsToken",
-                                             sessionVisits, @"visits",
-                                             sessionDuration, @"duration",
+                                             @(sessionVisits), @"visits",
+                                             @(sessionDuration), @"duration",
                                              nil];
 
                     NSData* postData = [NSJSONSerialization dataWithJSONObject:dataDic options:0 error:nil];

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -3519,12 +3519,12 @@ static id isNil(id object) {
 
                     long sessionEndedTimestamp = [[NSDate date] timeIntervalSince1970];
                     long sessionDuration = sessionEndedTimestamp - sessionStartedTimestamp;
+                    long visits = MAX(sessionVisits, 0);
 
                     if (channelId == nil || subscriptionId == nil || deviceToken == nil || sessionDuration < 0) {
                         return;
                     }
 
-                    NSInteger visits = MAX(sessionVisits, 0);
                     NSMutableURLRequest* request = [[CleverPushHTTPClient sharedClient] requestWithMethod:HTTP_POST path:@"subscription/session/end"];
                     NSDictionary* dataDic = [NSDictionary dictionaryWithObjectsAndKeys:
                                              channelId, @"channelId",

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -3520,16 +3520,17 @@ static id isNil(id object) {
                     long sessionEndedTimestamp = [[NSDate date] timeIntervalSince1970];
                     long sessionDuration = sessionEndedTimestamp - sessionStartedTimestamp;
 
-                    if (channelId == nil || subscriptionId == nil || deviceToken == nil || sessionVisits < 0 || sessionDuration < 0) {
+                    if (channelId == nil || subscriptionId == nil || deviceToken == nil || sessionDuration < 0) {
                         return;
                     }
 
+                    NSInteger visits = MAX(sessionVisits, 0);
                     NSMutableURLRequest* request = [[CleverPushHTTPClient sharedClient] requestWithMethod:HTTP_POST path:@"subscription/session/end"];
                     NSDictionary* dataDic = [NSDictionary dictionaryWithObjectsAndKeys:
                                              channelId, @"channelId",
                                              subscriptionId, @"subscriptionId",
                                              deviceToken, @"apnsToken",
-                                             @(sessionVisits), @"visits",
+                                             @(visits), @"visits",
                                              @(sessionDuration), @"duration",
                                              nil];
 


### PR DESCRIPTION
Optimised `trackSessionEnd` to prevent crash.