### PR TITLE
feature/CP-9006-ios-sdk-automatically-show-app-banner-when-app-is-open-in-the-foreground-and-handle-notification-received-is-called-via-silent-push

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1962,7 +1962,12 @@ static id isNil(id object) {
     bool isSilent = [notification objectForKey:@"silent"] != nil && ![[notification objectForKey:@"silent"] isKindOfClass:[NSNull class]] && [[notification objectForKey:@"silent"] boolValue];
 
     if (![CPUtils isNullOrEmpty:appBanner] && isSilent) {
-        [CPAppBannerModuleInstance setSilentPushAppBannersIds:appBanner notificationId:notificationId];
+        BOOL isActive = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
+        if (isActive) {
+            [self showAppBanner:appBanner channelId:[messageDict cleverPushStringForKeyPath:@"channel._id"] notificationId:notificationId];
+        } else {
+            [CPAppBannerModuleInstance setSilentPushAppBannersIds:appBanner notificationId:notificationId];
+        }
     }
 }
 


### PR DESCRIPTION
Implemented functionality of app banners should be displayed while the application is in foreground mode and the push notification type is a silent push.