### PR TITLE
hotfix/CP-8540-ios-sdk-handle-space-in-the-hex-string-values-for-the-ui-elements-in-app-banners

### DIFF
--- a/CleverPush/Source/UIColor+HexString.m
+++ b/CleverPush/Source/UIColor+HexString.m
@@ -8,7 +8,14 @@
         return [UIColor blackColor];
     }
 
-    NSString *colorString = [[hexString stringByReplacingOccurrencesOfString: @"#" withString: @""] uppercaseString];
+    NSString *colorString = [[hexString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]
+                              stringByReplacingOccurrencesOfString:@"#" withString:@""];
+    colorString = [[colorString stringByReplacingOccurrencesOfString:@" " withString:@""] uppercaseString];
+
+    if (colorString.length == 0) {
+        return [UIColor blackColor];
+    }
+
     CGFloat alpha, red, blue, green;
     switch ([colorString length]) {
         case 3: // #RGB


### PR DESCRIPTION
Resolved the crash issue if there was a space in the input colour in the app banners.