### PR TITLE
hotfix/CP-9149-ios-sdk-handle-the-warning-ui-application-delegate-must-be-called-from-main-thread-only

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1214,9 +1214,11 @@ static id isNil(id object) {
 - (void)handleSubscriptionWithCompletion:(void (^)(NSString * _Nullable, NSError * _Nullable))completion failure:(CPFailureBlock _Nullable)failureBlock skipTopicsDialog:(BOOL)skipTopicsDialog {
     hasCalledSubscribe = YES;
 
-    if (![UIApplication sharedApplication].isRegisteredForRemoteNotifications) {
-        [[UIApplication sharedApplication] registerForRemoteNotifications];
-    }
+    [self ensureMainThreadSync:^{
+        if (![UIApplication sharedApplication].isRegisteredForRemoteNotifications) {
+            [[UIApplication sharedApplication] registerForRemoteNotifications];
+        }
+    }];
 
     if (!deviceToken) {
         [self waitForDeviceTokenWithCompletion:^{


### PR DESCRIPTION
Optimised `handleSubscriptionWithCompletion` function for [UIApplication isRegisteredForRemoteNotifications] & [UIApplication registerForRemoteNotifications] is called on the main thread to avoid threading issues.