### PR TITLE
hotfix/CP-7807-ios-sdk-make-launch-options-in-init-optional

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -458,9 +458,11 @@ static id isNil(id object) {
     }
 
     NSDictionary* userInfo = [launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
-    if (userInfo) {
-        startFromNotification = YES;
-    }
+        if (userInfo) {
+            startFromNotification = YES;
+        } else if (!launchOptions) {
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didFinishLaunching:) name:UIApplicationDidFinishLaunchingNotification object:nil];
+        }
 
     if (pendingOpenedResult && handleNotificationOpened) {
         handleNotificationOpened(pendingOpenedResult);
@@ -513,6 +515,16 @@ static id isNil(id object) {
     }
 
     return self;
+}
+
+- (void)didFinishLaunching:(NSNotification *)notification {
+    NSDictionary *launchOptions = notification.userInfo;
+    NSDictionary* userInfo = [launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
+    if (userInfo) {
+        startFromNotification = YES;
+    }
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidFinishLaunchingNotification object:nil];
 }
 
 #pragma mark - Define the rootview controller of the UINavigation-Stack

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -458,11 +458,11 @@ static id isNil(id object) {
     }
 
     NSDictionary* userInfo = [launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
-        if (userInfo) {
-            startFromNotification = YES;
-        } else if (!launchOptions) {
-            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didFinishLaunching:) name:UIApplicationDidFinishLaunchingNotification object:nil];
-        }
+    if (userInfo) {
+        startFromNotification = YES;
+    } else if (!launchOptions) {
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onDidFinishLaunchingNotification:) name:UIApplicationDidFinishLaunchingNotification object:nil];
+    }
 
     if (pendingOpenedResult && handleNotificationOpened) {
         handleNotificationOpened(pendingOpenedResult);
@@ -517,7 +517,8 @@ static id isNil(id object) {
     return self;
 }
 
-- (void)didFinishLaunching:(NSNotification *)notification {
+#pragma mark - Handle App Launch Notification
+- (void)onDidFinishLaunchingNotification:(NSNotification *)notification {
     NSDictionary *launchOptions = notification.userInfo;
     NSDictionary* userInfo = [launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
     if (userInfo) {


### PR DESCRIPTION
Optimized `initWithLaunchOptions` to handle nil launchOptions by observing didFinishLaunchingNotification.