### PR TITLE
hotfix/CP-9373-ios-set-show-app-banner-callback-is-not-calling-every-time

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -1197,8 +1197,8 @@ NSInteger currentScreenIndex = 0;
     }
 }
 
-- (void)presentAppBanner:(CPAppBannerViewController*)appBannerViewController  banner:(CPAppBanner*)banner {
-    if ([CleverPush popupVisible]) {
+- (void)presentAppBanner:(CPAppBannerViewController*)appBannerViewController banner:(CPAppBanner*)banner {
+    if ([CleverPush popupVisible] && !handleBannerDisplayed) {
         [activePendingBanners addObject:banner];
         return;
     }


### PR DESCRIPTION
Resolved issue where `setShowAppBannerCallback` was sometimes not called due to the `popupVisible` condition