### PR TITLE
hotfix/CP-9408-ios-sdk-app-gets-crashed-if-we-set-subscription-attribute-value-to-nil

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -2510,7 +2510,12 @@ static id isNil(id object) {
                 if (!subscriptionAttributes) {
                     subscriptionAttributes = [[NSMutableDictionary alloc] init];
                 }
-                [subscriptionAttributes setObject:value forKey:attributeId];
+                
+                if (value == nil) {
+                    [subscriptionAttributes setObject:@"" forKey:attributeId];
+                } else {
+                    [subscriptionAttributes setObject:value forKey:attributeId];
+                }
                 [userDefaults setObject:subscriptionAttributes forKey:CLEVERPUSH_SUBSCRIPTION_ATTRIBUTES_KEY];
                 [userDefaults synchronize];
 

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -2510,7 +2510,6 @@ static id isNil(id object) {
                 if (!subscriptionAttributes) {
                     subscriptionAttributes = [[NSMutableDictionary alloc] init];
                 }
-                
                 if (value == nil) {
                     [subscriptionAttributes setObject:@"" forKey:attributeId];
                 } else {


### PR DESCRIPTION
Resolved the issue of the application crashing if we set the value as nil for the `setSubscriptionAttribute`