### PR TITLE
hotfix/CP-9457-ios-sdk-trackevent-with-numbers-getting-crashed

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -3210,10 +3210,7 @@ static id isNil(id object) {
                 for (NSString *key in properties) {
                     id value = [properties objectForKey:key];
                     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-                        [databaseManager updateCountForEventWithId:eventId
-                                                        eventValue:[NSString stringWithFormat:@"%@", value]
-                                                     eventProperty:[NSString stringWithFormat:@"%@", key]
-                                                 updatedDateTime:[CPUtils getCurrentTimestampWithFormat:@"yyyy-MM-dd HH:mm:ss"]];
+                        [databaseManager updateCountForEventWithId:eventId eventValue:[NSString stringWithFormat:@"%@", value] eventProperty:[NSString stringWithFormat:@"%@", key] updatedDateTime:[CPUtils getCurrentTimestampWithFormat:@"yyyy-MM-dd HH:mm:ss"]];
                     });
                 }
             } else {

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -3210,7 +3210,10 @@ static id isNil(id object) {
                 for (NSString *key in properties) {
                     id value = [properties objectForKey:key];
                     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-                        [databaseManager updateCountForEventWithId:eventId eventValue:value eventProperty:key updatedDateTime:[CPUtils getCurrentTimestampWithFormat:@"yyyy-MM-dd HH:mm:ss"]];
+                        [databaseManager updateCountForEventWithId:eventId
+                                                        eventValue:[NSString stringWithFormat:@"%@", value]
+                                                     eventProperty:[NSString stringWithFormat:@"%@", key]
+                                                 updatedDateTime:[CPUtils getCurrentTimestampWithFormat:@"yyyy-MM-dd HH:mm:ss"]];
                     });
                 }
             } else {


### PR DESCRIPTION
Optimised `trackEvent` the function to handle crashes where the argument contains numbers.