### PR TITLE
hotfix/CP-9473-ios-sdk-optimise-the-color-with-hex-string-function-for-preventing-the-crash

### DIFF
--- a/CleverPush/Source/UIColor+HexString.m
+++ b/CleverPush/Source/UIColor+HexString.m
@@ -43,8 +43,7 @@
             blue  = [self colorComponentFrom: colorString start: 6 length: 2];
             break;
         default:
-            [NSException raise:@"Invalid color value" format: @"Color value %@ is invalid. It should be a hex value of the form #RBG, #ARGB, #RRGGBB, or #AARRGGBB", hexString];
-            break;
+            return [UIColor blackColor];
     }
     return [UIColor colorWithRed: red green: green blue: blue alpha: alpha];
 }


### PR DESCRIPTION
Optimised the `colorWithHexString` function to prevent crashes when providing an invalid color code.