### PR TITLE
feature/CP-9470-ios-create-app-banner-close-listener

### DIFF
--- a/CleverPush/Source/CPAppBannerModule.h
+++ b/CleverPush/Source/CPAppBannerModule.h
@@ -29,6 +29,7 @@
 + (void)showBanner:(NSString*)channelId bannerId:(NSString*)bannerId notificationId:(NSString*)notificationId force:(BOOL)force;
 + (void)setBannerOpenedCallback:(CPAppBannerActionBlock)callback;
 + (void)setBannerShownCallback:(CPAppBannerShownBlock)callback;
++ (void)setBannerClosedCallback:(CPAppBannerClosedBlock)callback;
 + (void)setShowAppBannerCallback:(CPAppBannerDisplayBlock)callback;
 + (void)getBanners:(NSString*)channelId bannerId:(NSString*)bannerId notificationId:(NSString*)notificationId groupId:(NSString*)groupId completion:(void(^)(NSMutableArray<CPAppBanner*>*))callback;
 + (void)presentAppBanner:(UIViewController*)controller banner:(CPAppBanner*)banner;

--- a/CleverPush/Source/CPAppBannerModule.m
+++ b/CleverPush/Source/CPAppBannerModule.m
@@ -37,6 +37,11 @@ static CPAppBannerModuleInstance* singletonInstance = nil;
     [self.moduleInstance setBannerShownCallback:callback];
 }
 
+#pragma mark - Callback while banner has been closed
++ (void)setBannerClosedCallback:(CPAppBannerClosedBlock)callback {
+    [self.moduleInstance setBannerClosedCallback:callback];
+}
+
 #pragma mark - Callback while banner has been ready to display
 + (void)setShowAppBannerCallback:(CPAppBannerDisplayBlock)callback {
     [self.moduleInstance setShowAppBannerCallback:callback];

--- a/CleverPush/Source/CPAppBannerModuleInstance.h
+++ b/CleverPush/Source/CPAppBannerModuleInstance.h
@@ -31,6 +31,7 @@
 - (void)saveSessions;
 - (void)setBannerOpenedCallback:(CPAppBannerActionBlock)callback;
 - (void)setBannerShownCallback:(CPAppBannerShownBlock)callback;
+- (void)setBannerClosedCallback:(CPAppBannerClosedBlock)callback;
 - (void)setShowAppBannerCallback:(CPAppBannerDisplayBlock)callback;
 - (void)triggerEvent:(NSString *)eventId properties:(NSDictionary *)properties;
 - (void)showBanner:(NSString*)channelId bannerId:(NSString*)bannerId;

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -26,6 +26,7 @@ NSMutableArray* pendingBannerListeners;
 NSMutableArray<NSDictionary*> *events;
 CPAppBannerActionBlock handleBannerOpened;
 CPAppBannerShownBlock handleBannerShown;
+CPAppBannerClosedBlock handleBannerClosed;
 CPSQLiteManager *sqlManager;
 CPAppBannerDisplayBlock handleBannerDisplayed;
 
@@ -64,6 +65,11 @@ NSInteger currentScreenIndex = 0;
 #pragma mark - Call back while banner has been open-up successfully
 - (void)setBannerShownCallback:(CPAppBannerShownBlock)callback {
     handleBannerShown = callback;
+}
+
+#pragma mark - Call back while banner has been closed
+- (void)setBannerClosedCallback:(CPAppBannerClosedBlock)callback {
+    handleBannerClosed = callback;
 }
 
 #pragma mark - Callback while banner has been successfully ready to display
@@ -1299,6 +1305,10 @@ NSInteger currentScreenIndex = 0;
     [appBannerViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
     appBannerViewController.data = banner;
 
+    if (handleBannerClosed) {
+        appBannerViewController.handleBannerClosed = handleBannerClosed;
+    }
+    
     UIViewController* topController = [CleverPush topViewController];
     if (handleBannerDisplayed) {
         handleBannerDisplayed(appBannerViewController);

--- a/CleverPush/Source/CPAppBannerViewController.h
+++ b/CleverPush/Source/CPAppBannerViewController.h
@@ -32,6 +32,7 @@
 @property (strong, nonatomic) CPAppBanner *data;
 @property (nonatomic, strong) IBOutlet CPAspectKeepImageView *backGroundImage;
 @property (nonatomic, copy) CPAppBannerActionBlock actionCallback;
+@property (nonatomic,copy) CPAppBannerClosedBlock handleBannerClosed;
 @property (nonatomic, assign) long index;
 @property (nonatomic, strong) NSString *voucherCode;
 @property (nonatomic, strong) IBOutlet WKWebView *webView;

--- a/CleverPush/Source/CPAppBannerViewController.m
+++ b/CleverPush/Source/CPAppBannerViewController.m
@@ -472,7 +472,11 @@ static CPAppBannerActionBlock appBannerActionCallback;
     CPBannerCardContainer *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"CPBannerCardContainer" forIndexPath:indexPath];
     cell.data = self.data;
     [cell setActionCallback:self.actionCallback];
-
+    
+    if (self.handleBannerClosed) {
+        cell.handleBannerClosed = self.handleBannerClosed;
+    }
+    
     if (self.voucherCode != nil && ![self.voucherCode isKindOfClass:[NSNull class]] && ![self.voucherCode isEqualToString:@""]) {
         cell.voucherCode = self.voucherCode;
     }
@@ -889,6 +893,9 @@ static CPAppBannerActionBlock appBannerActionCallback;
         [self jumpOut];
         [[NSUserDefaults standardUserDefaults] setBool:false forKey:CLEVERPUSH_APP_BANNER_VISIBLE_KEY];
         [[NSUserDefaults standardUserDefaults] synchronize];
+        if (self.handleBannerClosed) {
+            self.handleBannerClosed();
+        }
         [self dismissViewControllerAnimated:NO completion:nil];
         [CPAppBannerModule showNextActivePendingBanner:self.data];
     });

--- a/CleverPush/Source/CPBannerCardContainer.h
+++ b/CleverPush/Source/CPBannerCardContainer.h
@@ -28,6 +28,7 @@
 @property (nonatomic, strong) NSMutableArray<CPAppBannerBlock*> *blocks;
 @property (strong, nonatomic) CPAppBanner *data;
 @property (nonatomic, copy) CPAppBannerActionBlock actionCallback;
+@property (nonatomic,copy) CPAppBannerClosedBlock handleBannerClosed;
 @property (nonatomic, assign) id controller;
 @property (nonatomic, weak) id <HeightDelegate> delegate;
 @property (nonatomic, weak) id <NavigateNextPage> changePage;

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -537,6 +537,9 @@
     dispatch_async(dispatch_get_main_queue(), ^(void) {
         [[NSUserDefaults standardUserDefaults] setBool:false forKey:CLEVERPUSH_APP_BANNER_VISIBLE_KEY];
         [[NSUserDefaults standardUserDefaults] synchronize];
+        if (self.handleBannerClosed) {
+            self.handleBannerClosed();
+        }
         [self.controller dismissViewControllerAnimated:NO completion:nil];
     });
 }

--- a/CleverPush/Source/CleverPush.h
+++ b/CleverPush/Source/CleverPush.h
@@ -174,6 +174,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 + (void)showAppBanner:(NSString* _Nullable)bannerId;
 + (void)setAppBannerOpenedCallback:(CPAppBannerActionBlock _Nullable)callback;
 + (void)setAppBannerShownCallback:(CPAppBannerShownBlock _Nullable)callback;
++ (void)setAppBannerClosedCallback:(CPAppBannerClosedBlock _Nullable)callback;
 + (void)setShowAppBannerCallback:(CPAppBannerDisplayBlock _Nullable)callback;
 + (void)getAppBanners:(NSString* _Nullable)channelId callback:(void(^ _Nullable)(NSMutableArray <CPAppBanner*>* _Nullable))callback;
 + (void)getAppBannersByGroup:(NSString* _Nullable)groupId callback:(void(^ _Nullable)(NSMutableArray <CPAppBanner*>* _Nullable))callback;

--- a/CleverPush/Source/CleverPush.m
+++ b/CleverPush/Source/CleverPush.m
@@ -588,6 +588,12 @@ static CleverPush* singleInstance = nil;
     }];
 }
 
++ (void)setAppBannerClosedCallback:(CPAppBannerClosedBlock _Nullable)callback {
+    [self.CPSharedInstance setAppBannerClosedCallback:^{
+        callback();
+    }];
+}
+
 + (void)setShowAppBannerCallback:(CPAppBannerDisplayBlock _Nullable)callback {
     [self.CPSharedInstance setShowAppBannerCallback:^(UIViewController*viewController) {
         callback(viewController);

--- a/CleverPush/Source/CleverPushInstance.h
+++ b/CleverPush/Source/CleverPushInstance.h
@@ -59,6 +59,7 @@ typedef void (^CPFailureBlock)(NSError* _Nullable error);
 typedef void (^CPAppBannerActionBlock)(CPAppBannerAction* _Nullable action);
 typedef void (^CPAppBannerShownBlock)(CPAppBanner* _Nullable appBanner);
 typedef void (^CPAppBannerDisplayBlock)(UIViewController * _Nullable viewController);
+typedef void (^CPAppBannerClosedBlock)(void);
 
 typedef void (^CPLogListener)(NSString* _Nullable message);
 
@@ -208,6 +209,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 - (void)getAppBannersByGroup:(NSString* _Nullable)groupId callback:(void(^ _Nullable)(NSMutableArray <CPAppBanner*>* _Nullable))callback;
 - (void)setAppBannerOpenedCallback:(CPAppBannerActionBlock _Nullable)callback;
 - (void)setAppBannerShownCallback:(CPAppBannerShownBlock _Nullable)callback;
+- (void)setAppBannerClosedCallback:(CPAppBannerClosedBlock _Nullable)callback;
 - (void)setShowAppBannerCallback:(CPAppBannerDisplayBlock _Nullable)callback;
 - (void)setApiEndpoint:(NSString* _Nullable)apiEndpoint;
 - (void)setAppGroupIdentifierSuffix:(NSString* _Nullable)suffix;

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -3949,6 +3949,10 @@ static id isNil(id object) {
     [CPAppBannerModule setBannerShownCallback:callback];
 }
 
+- (void)setAppBannerClosedCallback:(CPAppBannerClosedBlock _Nullable)callback {
+    [CPAppBannerModule setBannerClosedCallback:callback];
+}
+
 - (void)setShowAppBannerCallback:(CPAppBannerDisplayBlock _Nullable)callback {
     [CPAppBannerModule setShowAppBannerCallback:callback];
 }


### PR DESCRIPTION
implemented a listener callback for when the app banner is dismissed.