### PR TITLE
feature/cp-9080-ios-new-api-endpoint-not-used-after-setapiendpoint-is-called

### DIFF
--- a/CleverPush/Source/CleverPushHTTPClient.h
+++ b/CleverPush/Source/CleverPushHTTPClient.h
@@ -6,5 +6,6 @@
 + (CleverPushHTTPClient *)sharedClient;
 @property (readonly, nonatomic) NSURL *apiEndpoint;
 - (NSMutableURLRequest*) requestWithMethod:(NSString*)method path:(NSString*)path;
+- (void)configureEndpoint:(NSString*)endpoint;
 
 @end

--- a/CleverPush/Source/CleverPushHTTPClient.m
+++ b/CleverPush/Source/CleverPushHTTPClient.m
@@ -42,4 +42,9 @@
     return request;
 }
 
+#pragma mark - Configure the API endpoint
+- (void)configureEndpoint:(NSString*)endpoint {
+    [self setValue:[NSURL URLWithString:[NSString stringWithFormat:@"%@/", endpoint]] forKey:@"apiEndpoint"];
+}
+
 @end

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -3917,6 +3917,7 @@ static id isNil(id object) {
 
 - (void)setApiEndpoint:(NSString* _Nullable)endpoint {
     apiEndpoint = endpoint;
+    [[CleverPushHTTPClient sharedClient] configureEndpoint:endpoint];
 }
 
 - (void)setAppGroupIdentifierSuffix:(NSString* _Nullable)suffix {


### PR DESCRIPTION
Optimise `setApiEndpoint` function for updating the api endpoint.