### PR TITLE
hotfix/cp-9220-in-app-banner-add-string-array-check-to-attribute-targeting

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -630,6 +630,10 @@ NSInteger currentScreenIndex = 0;
                 toValue = @"";
             }
 
+            if ([CPUtils isNullOrEmpty:relation]) {
+                relation = @"equals";
+            }
+            
             if ([attributeValue isKindOfClass:[NSArray class]]) {
                 NSArray *availableValues = (NSArray *)attributeValue;
                 BOOL matchFound = NO;
@@ -642,16 +646,17 @@ NSInteger currentScreenIndex = 0;
                 }
 
                 if (!matchFound) {
-                    return NO;
+                    if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeNotContains)]) {
+                        attributeValue = @"";
+                    } else {
+                        return NO;
+                    }
+                    
                 }
             }
 
-            if ([CPUtils isNullOrEmpty:attributeValue]) {
+            if (![relation isEqualToString:filterRelationType(CPFilterRelationTypeNotContains)] && [CPUtils isNullOrEmpty:attributeValue]) {
                 return NO;
-            }
-
-            if ([CPUtils isNullOrEmpty:relation]) {
-                relation = @"equals";
             }
 
             BOOL attributeFilterAllowed = [self checkRelationFilter:attributeValue compareWith:compareAttributeValue relation:relation isAllowed:allowed compareWithFrom:fromValue compareWithTo:toValue];


### PR DESCRIPTION
Resolved the issue of the in-app banner targeting attribute with not contains" not working.