### PR TITLE
hotfix/cp-9259-unexpected-click-data-in-ios-banner-stats

### DIFF
--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -470,7 +470,6 @@
     }
 }
 
-
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
     if (self.blocks[indexPath.row].type == CPAppBannerBlockTypeHTML) {
         CPAppBannerHTMLBlock *block = (CPAppBannerHTMLBlock*)self.blocks[indexPath.row];

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -358,9 +358,9 @@
                 }
             }
 
-            [CPAppBannerModule sendBannerEvent:@"clicked" forBanner:self.data forScreen:screen forButtonBlock:block forImageBlock:nil blockType:@"button"];
-
             if (hasActionsArray) {
+                [CPAppBannerModule sendBannerEvent:@"clicked" forBanner:self.data forScreen:screen forButtonBlock:block forImageBlock:nil blockType:@"button"];
+                
                 [self actionCallback:block.action actions:block.actions from:YES];
             } else {
                 [self actionCallback:block.action from:YES];
@@ -459,15 +459,17 @@
                 }
             }
         }
-        [CPAppBannerModule sendBannerEvent:@"clicked" forBanner:self.data forScreen:screen forButtonBlock:nil forImageBlock:block blockType:@"image"];
-
+        
         if (hasActionsArray) {
+            [CPAppBannerModule sendBannerEvent:@"clicked" forBanner:self.data forScreen:screen forButtonBlock:nil forImageBlock:block blockType:@"image"];
+            
             [self actionCallback:block.action actions:block.actions from:NO];
         } else {
             [self actionCallback:block.action from:NO];
         }
     }
 }
+
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
     if (self.blocks[indexPath.row].type == CPAppBannerBlockTypeHTML) {


### PR DESCRIPTION
Resolved the issue of unexpected click events when actions were not defined in image and button blocks in app banners.