### PR TITLE
hotfix/cp-9165-ios-service-extension-not-showing-images-if-the-filename

### DIFF
--- a/CleverPush/Source/CPUtils.h
+++ b/CleverPush/Source/CPUtils.h
@@ -12,6 +12,7 @@
 
 #pragma mark - Utilities singleton functions
 + (NSString*)downloadMedia:(NSString*)urlString;
++ (NSString*)extensionFromMimeType:(NSString*)mimeType;
 + (NSDictionary *)dictionaryWithPropertiesOfObject:(id)obj;
 + (NSInteger)daysBetweenDate:(NSDate*)fromDateTime andDate:(NSDate*)toDateTime;
 + (void)updateLastTopicCheckedTime;


### PR DESCRIPTION
Resolved the issue of the image not displaying if the filename does not end with .jpg or .png and a push is sent from the API.