### PR TITLE
hotfix/cp-9350-ios-reactnative-exc_bad_access-initbannerswithchannel

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -713,8 +713,10 @@ static id isNil(id object) {
         [self showTopicDialogOnNewAdded];
         [self initAppReview];
 
-        [CPAppBannerModule initBannersWithChannel:channelId showDrafts:isShowDraft fromNotification:NO];
-        [CPAppBannerModule initSession:channelId afterInit:NO];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [CPAppBannerModule initBannersWithChannel:channelId showDrafts:isShowDraft fromNotification:NO];
+            [CPAppBannerModule initSession:channelId afterInit:NO];
+        });
     });
 }
 


### PR DESCRIPTION
Optimized `initFeatures` functions for preventing crashes regarding the UI thread.