### PR TITLE
feature/cp-9460-ios-add-contains-substring-relation-logic-to-in-app-banner

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -669,8 +669,6 @@ int appBannerPerDayValue = 0;
                     } else {
                         return NO;
                     }
-                } else if ([attributeValue isKindOfClass:[NSArray class]]) {
-                    attributeValue = @"";
                 }
             }
 

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -646,7 +646,17 @@ int appBannerPerDayValue = 0;
                 NSArray *availableValues = (NSArray *)attributeValue;
                 BOOL matchFound = NO;
                 for (NSString *arrayItem in availableValues) {
-                    if ([arrayItem isEqualToString:compareAttributeValue]) {
+                    if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeContainsSubstring)] &&
+                        (![CPUtils isNullOrEmpty:compareAttributeValue] && [compareAttributeValue containsString:arrayItem])) {
+                        attributeValue = arrayItem;
+                        matchFound = YES;
+                        break;
+                    } else if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeContains)] &&
+                               (![CPUtils isNullOrEmpty:arrayItem] && [arrayItem containsString:compareAttributeValue])) {
+                        attributeValue = arrayItem;
+                        matchFound = YES;
+                        break;
+                    } else if ([arrayItem isEqualToString:compareAttributeValue]) {
                         attributeValue = arrayItem;
                         matchFound = YES;
                         break;
@@ -659,7 +669,8 @@ int appBannerPerDayValue = 0;
                     } else {
                         return NO;
                     }
-                    
+                } else if ([attributeValue isKindOfClass:[NSArray class]]) {
+                    attributeValue = @"";
                 }
             }
 
@@ -667,7 +678,12 @@ int appBannerPerDayValue = 0;
                 ([CPUtils isNullOrEmpty:attributeValue] && banner.attributesLogic == CPAppBannerAttributeLogicTypeAnd)) {
                 return NO;
             }
-
+            
+            if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeContainsSubstring)] &&
+                (![CPUtils isNullOrEmpty:compareAttributeValue] && ![compareAttributeValue containsString:attributeValue])) {
+                return NO;
+            }
+     
             BOOL attributeFilterAllowed = [self checkRelationFilter:attributeValue compareWith:compareAttributeValue relation:relation isAllowed:allowed compareWithFrom:fromValue compareWithTo:toValue];
 
             if (attributeFilterAllowed && banner.attributesLogic == CPAppBannerAttributeLogicTypeOr) {
@@ -821,6 +837,10 @@ int appBannerPerDayValue = 0;
         if ([value rangeOfString:compareValue].location != NSNotFound) {
             allowed = NO;
         }
+    } else if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeContainsSubstring)]) {
+        if ([compareValue rangeOfString:value].location == NSNotFound) {
+            allowed = NO;
+        }
     }
     return allowed;
 }
@@ -861,6 +881,10 @@ int appBannerPerDayValue = 0;
         }
     } else if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeNotContains)]) {
         if ([value rangeOfString:compareValue].location != NSNotFound) {
+            allowed = NO;
+        }
+    } else if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeContainsSubstring)]) {
+        if ([compareValue rangeOfString:value].location == NSNotFound) {
             allowed = NO;
         }
     }

--- a/CleverPush/Source/CPFilterRelationType.h
+++ b/CleverPush/Source/CPFilterRelationType.h
@@ -5,7 +5,8 @@ typedef NS_ENUM(NSInteger, CPFilterRelationType) {
     CPFilterRelationTypeBetween,
     CPFilterRelationTypeNotEqual,
     CPFilterRelationTypeContains,
-    CPFilterRelationTypeNotContains
+    CPFilterRelationTypeNotContains,
+    CPFilterRelationTypeContainsSubstring
 };
 
-#define filterRelationType(enum) [@[@"equals",@"lessThan",@"greaterThan",@"between",@"notEquals",@"contains",@"notContains"] objectAtIndex:enum]
+#define filterRelationType(enum) [@[@"equals",@"lessThan",@"greaterThan",@"between",@"notEquals",@"contains",@"notContains",@"containsSubstring"] objectAtIndex:enum]


### PR DESCRIPTION
Add Contains Substring Relation Logic to In-App-Banner Targeting with Attributes
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added "contains substring" relation logic to in-app banner targeting, allowing banners to match attributes that include a specific substring.

- **New Features**
  - Supports "contains substring" as a filter option for banner attribute targeting.

<!-- End of auto-generated description by cubic. -->

