### PR TITLE
hotfix/cp-9516-flutter-subscribe-not-resolving-when-channel-has-no-topics

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -3719,9 +3719,9 @@ static id isNil(id object) {
             [self getSubscriptionId:^(NSString *subscriptionId) {
                 if (subscriptionId) {
                     handlePendingSubscriptionCallback(subscriptionId);
-                    isTopicsDialogBeingShown = NO;
-                    handlePendingSubscriptionCallback = nil;
                 }
+                isTopicsDialogBeingShown = NO;
+                handlePendingSubscriptionCallback = nil;
             }];
         }
     }
@@ -3750,9 +3750,9 @@ static id isNil(id object) {
                 [self getSubscriptionId:^(NSString *subscriptionId) {
                     if (subscriptionId) {
                         handlePendingSubscriptionCallback(subscriptionId);
-                        isTopicsDialogBeingShown = NO;
-                        handlePendingSubscriptionCallback = nil;
                     }
+                    isTopicsDialogBeingShown = NO;
+                    handlePendingSubscriptionCallback = nil;
                 }];
             }
             return;
@@ -3807,9 +3807,9 @@ static id isNil(id object) {
                                     [self getSubscriptionId:^(NSString *subscriptionId) {
                                         if (subscriptionId) {
                                             handlePendingSubscriptionCallback(subscriptionId);
-                                            isTopicsDialogBeingShown = NO;
-                                            handlePendingSubscriptionCallback = nil;
                                         }
+                                        isTopicsDialogBeingShown = NO;
+                                        handlePendingSubscriptionCallback = nil;
                                     }];
                                 }
                             }];


### PR DESCRIPTION
Optimized subscribed callback functionality for the subscription flow.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where the subscription callback would not resolve if a channel had no topics in the Flutter integration.

- **Bug Fixes**
  - Ensured the subscription callback is always called, even when no topics are present.

<!-- End of auto-generated description by cubic. -->

