### PR TITLE
hotfix/cp-9544-ios-sdk-only-clicked-notification-should-be-removed-from-the

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -4017,18 +4017,6 @@ static id isNil(id object) {
     } else {
         [[UIApplication sharedApplication] setApplicationIconBadgeNumber:count];
     }
-    
-    if (count == 0) {
-        [center getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> *notifications) {
-            if (notifications.count > 0) {
-                NSMutableArray *identifiers = [NSMutableArray arrayWithCapacity:notifications.count];
-                for (UNNotification *notification in notifications) {
-                    [identifiers addObject:notification.request.identifier];
-                }
-                [center removeDeliveredNotificationsWithIdentifiers:identifiers];
-            }
-        }];
-    }
 }
 
 - (NSString* _Nullable)getApiEndpoint {


### PR DESCRIPTION
Optimized `setBadgeCount` function for removing other notifications. (Only clicked notifications should be removed from the notification centre (except that all should remain in the notification centre).)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the notification handling so only the clicked notification is removed from the notification center; all others now remain visible.

<!-- End of auto-generated description by cubic. -->

