### PR TITLE
hotfix/cp-9647-attribute-filter-issue-on-ios-in-app-banner-not-triggered

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -647,7 +647,7 @@ int appBannerPerDayValue = 0;
                 BOOL matchFound = NO;
                 for (NSString *arrayItem in availableValues) {
                     if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeContainsSubstring)] &&
-                        (![CPUtils isNullOrEmpty:compareAttributeValue] && [compareAttributeValue containsString:arrayItem])) {
+                        (![CPUtils isNullOrEmpty:compareAttributeValue] && [arrayItem containsString:compareAttributeValue])) {
                         attributeValue = arrayItem;
                         matchFound = YES;
                         break;
@@ -678,7 +678,7 @@ int appBannerPerDayValue = 0;
             }
             
             if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeContainsSubstring)] &&
-                (![CPUtils isNullOrEmpty:compareAttributeValue] && ![compareAttributeValue containsString:attributeValue])) {
+                (![CPUtils isNullOrEmpty:compareAttributeValue] && ![attributeValue containsString:compareAttributeValue])) {
                 return NO;
             }
      
@@ -836,7 +836,7 @@ int appBannerPerDayValue = 0;
             allowed = NO;
         }
     } else if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeContainsSubstring)]) {
-        if ([compareValue rangeOfString:value].location == NSNotFound) {
+        if ([value rangeOfString:compareValue].location == NSNotFound) {
             allowed = NO;
         }
     }
@@ -882,7 +882,7 @@ int appBannerPerDayValue = 0;
             allowed = NO;
         }
     } else if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeContainsSubstring)]) {
-        if ([compareValue rangeOfString:value].location == NSNotFound) {
+        if ([value rangeOfString:compareValue].location == NSNotFound) {
             allowed = NO;
         }
     }


### PR DESCRIPTION
Resolved the issue of attribute filter in-app banner not triggered
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where in-app banners with attribute filters were not triggering on iOS due to incorrect substring matching logic.

- **Bug Fixes**
  - Updated substring checks to ensure attribute filters work as expected for in-app banners.

<!-- End of auto-generated description by cubic. -->

