### PR TITLE
hotfix/cp-9561-ios-mobile-sdk-call-the-api-created-to-communicate-and-track

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -555,7 +555,8 @@ int appBannerPerDayValue = 0;
                 allowed = NO;
             }
         } else if ([NSLocale preferredLanguages].count > 0) {
-            NSString *preferredLanguage = [[NSBundle mainBundle] preferredLocalizations].firstObject;
+            NSString *preferredLanguage = [NSLocale preferredLanguages].firstObject;
+            preferredLanguage = [[preferredLanguage componentsSeparatedByString:@"-"] firstObject];
             if (![banner.languages containsObject:preferredLanguage]) {
                 allowed = NO;
             }

--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -216,6 +216,21 @@ CPNotificationClickBlock handleClick;
     if (self.notifications[indexPath.row].inboxAppBanner != nil && ![self.notifications[indexPath.row].inboxAppBanner isKindOfClass:[NSNull class]] )  {
         [self showAppBanner:self.notifications[indexPath.row].inboxAppBanner notificationId:self.notifications[indexPath.row].id];
     }
+    
+    NSString* path = [NSString stringWithFormat:@"/channel/%@/panel/clicked", [CleverPush channelId]];
+    NSMutableURLRequest* request = [[CleverPushHTTPClient sharedClient] requestWithMethod:HTTP_POST path:path];
+
+    NSDictionary* dataDic = [NSDictionary dictionaryWithObjectsAndKeys:
+                             [CleverPush channelId], @"channelId",
+                             self.notifications[indexPath.row].id, @"notificationId",
+                             nil];
+
+    NSData* postData = [NSJSONSerialization dataWithJSONObject:dataDic options:0 error:nil];
+    [request setHTTPBody:postData];
+
+    [CleverPush enqueueRequest:request onSuccess:nil onFailure:^(NSError* error) {
+        [CPLog debug:@"Failed sending notification click event %@", error];
+    }];
 }
 
 - (void)saveReadNotifications:(NSMutableArray *)readNotifications{


### PR DESCRIPTION
Added an API call to track when a user clicks a notification in the InboxView.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an API call to track when a user clicks a notification in the InboxView, enabling better event tracking.

- **Bug Fixes**
 - Fixed language detection for app banner targeting by using the correct preferred language format.

<!-- End of auto-generated description by cubic. -->

