### PR TITLE
feature/cp-9509-flutterios-implement-setread-in-notification-class

### DIFF
--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -178,7 +178,7 @@ CPNotificationClickBlock handleClick;
         [cell.notificationDate setFont:[UIFont systemFontOfSize:(CGFloat)(10.0) weight:UIFontWeightSemibold]];
     }
 
-    if (![self.readNotifications containsObject:self.notifications[indexPath.row].id]) {
+    if ([self.readNotifications containsObject:self.notifications[indexPath.row].id]) {
         cell.backgroundColor = self.read_color;
     } else {
         cell.backgroundColor = self.unread_color;
@@ -222,13 +222,13 @@ CPNotificationClickBlock handleClick;
 }
 
 - (void)saveReadNotifications:(NSMutableArray *)readNotifications{
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSUserDefaults *defaults = [CPUtils getUserDefaultsAppGroup];
     [defaults setObject:readNotifications forKey:CLEVERPUSH_READ_NOTIFICATIONS_KEY];
     [defaults synchronize];
 }
 
 - (NSArray *)getReadNotifications {
-    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+    NSUserDefaults* userDefaults = [CPUtils getUserDefaultsAppGroup];
     NSArray* readNotifications = [userDefaults arrayForKey:CLEVERPUSH_READ_NOTIFICATIONS_KEY];
     if (!readNotifications) {
         return [[NSArray alloc] init];

--- a/CleverPush/Source/CPNotification.h
+++ b/CleverPush/Source/CPNotification.h
@@ -19,12 +19,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readwrite) BOOL chatNotification;
 @property (nonatomic, readwrite) BOOL carouselEnabled;
 @property (nonatomic, readwrite) BOOL silent;
+@property (nonatomic, readwrite) BOOL read;
 @property (nonatomic, strong, nullable) NSDate *createdAt;
 @property (nonatomic, strong, nullable) NSDate *expiresAt;
 #pragma mark - Class Methods
 + (instancetype)initWithJson:(NSDictionary*)json;
 - (void)parseJson:(NSDictionary*)json;
 - (void)trackInboxClicked;
+- (void)setRead:(BOOL)read;
+- (BOOL)getRead;
 NS_ASSUME_NONNULL_END
 
 @end

--- a/CleverPush/Source/CPNotification.m
+++ b/CleverPush/Source/CPNotification.m
@@ -15,6 +15,8 @@
 
 #pragma mark - Parse json and set the data to the object variables
 - (void)parseJson:(NSDictionary*)json {
+    self.read = NO;
+    
     if ([json objectForKey:@"_id"] != nil && ![[json objectForKey:@"_id"] isKindOfClass:[NSNull class]]) {
         self.id = [json objectForKey:@"_id"];
     }
@@ -115,6 +117,15 @@
     if (self.id) {
         [CleverPush trackInboxClicked:self.id];
     }
+}
+
+#pragma mark - Getters and Setters for read property
+- (void)setRead:(BOOL)read {
+    self.read = read;
+}
+
+- (BOOL)getRead {
+    return self.read;
 }
 
 @end


### PR DESCRIPTION
implemented setRead & getRead function for CPNotification object.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added setRead and getRead methods to the CPNotification class to manage the read state of notifications. This supports marking notifications as read or unread in the app.

<!-- End of auto-generated description by cubic. -->

