### PR TITLE
hotfix/cp-9725-ios-sdk-nsinvalidargumentexception-crash-in-cleverpush-ios

### DIFF
--- a/CleverPush/Source/CPAppBanner.m
+++ b/CleverPush/Source/CPAppBanner.m
@@ -88,7 +88,9 @@
 
         if ([json objectForKey:@"languages"] != nil) {
             for (NSString *supportedLanguage in [json objectForKey:@"languages"]) {
-                [self.languages addObject:supportedLanguage];
+                if (supportedLanguage != nil && ![supportedLanguage isKindOfClass:[NSNull class]] && [supportedLanguage isKindOfClass:[NSString class]]) {
+                    [self.languages addObject:supportedLanguage];
+                }
             }
         }
 
@@ -99,7 +101,9 @@
             && [json objectForKey:@"connectedBanners"] != nil
         ) {
             for (NSString *connectedBanner in [json objectForKey:@"connectedBanners"]) {
-                [self.connectedBanners addObject:connectedBanner];
+                if (connectedBanner != nil && ![connectedBanner isKindOfClass:[NSNull class]] && [connectedBanner isKindOfClass:[NSString class]]) {
+                    [self.connectedBanners addObject:connectedBanner];
+                }
             }
         }
 

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -169,14 +169,18 @@ int appBannerPerDayValue = 0;
 #pragma mark - update/set the NSUserDefaults of key CleverPush_SHOWN_APP_BANNERS
 - (void)setBannerIsShown:(CPAppBanner*)banner {
     NSMutableArray* shownAppBanners = [self shownAppBanners];
-    [shownAppBanners addObject:banner.id];
+    if (banner.id != nil && ![banner.id isKindOfClass:[NSNull class]] && [banner.id isKindOfClass:[NSString class]]) {
+        [shownAppBanners addObject:banner.id];
+    }
 
     if (banner.connectedBanners != nil) {
         for (NSString *connectedBannerId in banner.connectedBanners) {
             if ([shownAppBanners containsObject:connectedBannerId]) {
                 continue;
             }
-            [shownAppBanners addObject:connectedBannerId];
+            if (connectedBannerId != nil && ![connectedBannerId isKindOfClass:[NSNull class]] && [connectedBannerId isKindOfClass:[NSString class]]) {
+                [shownAppBanners addObject:connectedBannerId];
+            }
         }
     }
 
@@ -1291,7 +1295,9 @@ int appBannerPerDayValue = 0;
                 NSMutableArray *topics = [NSMutableArray arrayWithArray:[CleverPush getSubscriptionTopics]];
                 for (NSString *topic in action.topics) {
                     if (![topics containsObject:topic]) {
-                        [topics addObject:topic];
+                        if (topic != nil && ![topic isKindOfClass:[NSNull class]] && [topic isKindOfClass:[NSString class]]) {
+                            [topics addObject:topic];
+                        }
                     }
                 }
                 [CleverPush setSubscriptionTopics:topics];
@@ -1735,7 +1741,9 @@ int appBannerPerDayValue = 0;
     }
 
     if (!urlExists) {
-        [existingArray addObject:urlString];
+        if (urlString != nil && ![urlString isKindOfClass:[NSNull class]] && [urlString isKindOfClass:[NSString class]]) {
+            [existingArray addObject:urlString];
+        }
     }
 
     [CPAppBannerModuleInstance setBannersForDeepLink:existingArray];
@@ -1763,7 +1771,9 @@ int appBannerPerDayValue = 0;
         NSMutableDictionary *existingDict = [filteredArray.firstObject mutableCopy];
         existingDict[@"appBanner"] = appBannerId;
     } else {
-        [existingArray addObject:@{ @"notificationId": notificationId, @"appBanner": appBannerId }];
+        if (notificationId != nil && appBannerId != nil) {
+            [existingArray addObject:@{ @"notificationId": notificationId, @"appBanner": appBannerId }];
+        }
     }
 
     [defaults setObject:existingArray forKey:CLEVERPUSH_SILENT_PUSH_APP_BANNERS_KEY];

--- a/CleverPush/Source/CPAppBannerViewController.m
+++ b/CleverPush/Source/CPAppBannerViewController.m
@@ -928,12 +928,16 @@ static CPAppBannerActionBlock appBannerActionCallback;
     
     if (self.data.background.imageUrl && ![self.data.background.imageUrl isKindOfClass:[NSNull class]] && ![self.data.background.imageUrl isEqualToString:@""]) {
         if (![[CPUtils sharedImageCache] objectForKey:self.data.background.imageUrl]) {
-            [imageURLsToPreload addObject:self.data.background.imageUrl];
+            if (self.data.background.imageUrl != nil && ![self.data.background.imageUrl isKindOfClass:[NSNull class]] && [self.data.background.imageUrl isKindOfClass:[NSString class]]) {
+                [imageURLsToPreload addObject:self.data.background.imageUrl];
+            }
         }
     }
     if (self.data.background.darkImageUrl && ![self.data.background.darkImageUrl isKindOfClass:[NSNull class]] && ![self.data.background.darkImageUrl isEqualToString:@""]) {
         if (![[CPUtils sharedImageCache] objectForKey:self.data.background.darkImageUrl]) {
-            [imageURLsToPreload addObject:self.data.background.darkImageUrl];
+            if (self.data.background.darkImageUrl != nil && ![self.data.background.darkImageUrl isKindOfClass:[NSNull class]] && [self.data.background.darkImageUrl isKindOfClass:[NSString class]]) {
+                [imageURLsToPreload addObject:self.data.background.darkImageUrl];
+            }
         }
     }
     
@@ -942,14 +946,18 @@ static CPAppBannerActionBlock appBannerActionCallback;
         for (CPAppBannerBlock *block in screen.blocks) {
             if ([block isKindOfClass:[CPAppBannerImageBlock class]]) {
                 CPAppBannerImageBlock *imageBlock = (CPAppBannerImageBlock *)block;
-                if (imageBlock.imageUrl && ![imageBlock.imageUrl isKindOfClass:[NSNull class]] && ![imageBlock.imageUrl isEqualToString:@""]) {
+                if (imageBlock.imageUrl != nil && ![imageBlock.imageUrl isKindOfClass:[NSNull class]] && [imageBlock.imageUrl isKindOfClass:[NSString class]]) {
                     if (![[CPUtils sharedImageCache] objectForKey:imageBlock.imageUrl]) {
-                        [imageURLsToPreload addObject:imageBlock.imageUrl];
+                        if (imageBlock.imageUrl != nil && ![imageBlock.imageUrl isKindOfClass:[NSNull class]] && [imageBlock.imageUrl isKindOfClass:[NSString class]]) {
+                            [imageURLsToPreload addObject:imageBlock.imageUrl];
+                        }
                     }
                 }
-                if (imageBlock.darkImageUrl && ![imageBlock.darkImageUrl isKindOfClass:[NSNull class]] && ![imageBlock.darkImageUrl isEqualToString:@""]) {
+                if (imageBlock.darkImageUrl != nil && ![imageBlock.darkImageUrl isKindOfClass:[NSNull class]] && [imageBlock.darkImageUrl isKindOfClass:[NSString class]]) {
                     if (![[CPUtils sharedImageCache] objectForKey:imageBlock.darkImageUrl]) {
-                        [imageURLsToPreload addObject:imageBlock.darkImageUrl];
+                        if (imageBlock.darkImageUrl != nil && ![imageBlock.darkImageUrl isKindOfClass:[NSNull class]] && [imageBlock.darkImageUrl isKindOfClass:[NSString class]]) {
+                            [imageURLsToPreload addObject:imageBlock.darkImageUrl];
+                        }
                     }
                 }
             }
@@ -1039,12 +1047,16 @@ static CPAppBannerActionBlock appBannerActionCallback;
     NSMutableArray *imageURLsToPreload = [NSMutableArray array];
     if (banner.background.imageUrl && ![banner.background.imageUrl isKindOfClass:[NSNull class]] && ![banner.background.imageUrl isEqualToString:@""]) {
         if (![[CPUtils sharedImageCache] objectForKey:banner.background.imageUrl]) {
-            [imageURLsToPreload addObject:banner.background.imageUrl];
+            if (banner.background.imageUrl != nil && ![banner.background.imageUrl isKindOfClass:[NSNull class]] && [banner.background.imageUrl isKindOfClass:[NSString class]]) {
+                [imageURLsToPreload addObject:banner.background.imageUrl];
+            }
         }
     }
     if (banner.background.darkImageUrl && ![banner.background.darkImageUrl isKindOfClass:[NSNull class]] && ![banner.background.darkImageUrl isEqualToString:@""]) {
         if (![[CPUtils sharedImageCache] objectForKey:banner.background.darkImageUrl]) {
-            [imageURLsToPreload addObject:banner.background.darkImageUrl];
+            if (banner.background.darkImageUrl != nil && ![banner.background.darkImageUrl isKindOfClass:[NSNull class]] && [banner.background.darkImageUrl isKindOfClass:[NSString class]]) {
+                [imageURLsToPreload addObject:banner.background.darkImageUrl];
+            }
         }
     }
     
@@ -1052,14 +1064,18 @@ static CPAppBannerActionBlock appBannerActionCallback;
         for (CPAppBannerBlock *block in screen.blocks) {
             if ([block isKindOfClass:[CPAppBannerImageBlock class]]) {
                 CPAppBannerImageBlock *imageBlock = (CPAppBannerImageBlock *)block;
-                if (imageBlock.imageUrl && ![imageBlock.imageUrl isKindOfClass:[NSNull class]] && ![imageBlock.imageUrl isEqualToString:@""]) {
+                if (imageBlock.imageUrl != nil && ![imageBlock.imageUrl isKindOfClass:[NSNull class]] && [imageBlock.imageUrl isKindOfClass:[NSString class]]) {
                     if (![[CPUtils sharedImageCache] objectForKey:imageBlock.imageUrl]) {
-                        [imageURLsToPreload addObject:imageBlock.imageUrl];
+                        if (imageBlock.imageUrl != nil && ![imageBlock.imageUrl isKindOfClass:[NSNull class]] && [imageBlock.imageUrl isKindOfClass:[NSString class]]) {
+                            [imageURLsToPreload addObject:imageBlock.imageUrl];
+                        }
                     }
                 }
-                if (imageBlock.darkImageUrl && ![imageBlock.darkImageUrl isKindOfClass:[NSNull class]] && ![imageBlock.darkImageUrl isEqualToString:@""]) {
+                if (imageBlock.darkImageUrl != nil && ![imageBlock.darkImageUrl isKindOfClass:[NSNull class]] && [imageBlock.darkImageUrl isKindOfClass:[NSString class]]) {
                     if (![[CPUtils sharedImageCache] objectForKey:imageBlock.darkImageUrl]) {
-                        [imageURLsToPreload addObject:imageBlock.darkImageUrl];
+                        if (imageBlock.darkImageUrl != nil && ![imageBlock.darkImageUrl isKindOfClass:[NSNull class]] && [imageBlock.darkImageUrl isKindOfClass:[NSString class]]) {
+                            [imageURLsToPreload addObject:imageBlock.darkImageUrl];
+                        }
                     }
                 }
             }

--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -204,29 +204,20 @@ CPNotificationClickBlock handleClick;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    CPNotification *notification = self.notifications[indexPath.row];
-    BOOL isCurrentlyRead = [self.readNotifications containsObject:notification.id];
-    
-    if (!isCurrentlyRead) {
-        if (![self.readNotifications containsObject:notification.id]) {
-            [CleverPush setNotificationRead:notification.id read:true];
-            [self.readNotifications addObject:notification.id];
+    if (![self.readNotifications containsObject:self.notifications[indexPath.row].id]) {
+        id notifId = self.notifications[indexPath.row].id;
+        if (notifId != nil && ![notifId isKindOfClass:[NSNull class]] && [notifId isKindOfClass:[NSString class]]) {
+            [self.readNotifications addObject:notifId];
         }
-    } else {
-        if ([self.readNotifications containsObject:notification.id]) {
-            [CleverPush setNotificationRead:notification.id read:false];
-            [self.readNotifications removeObject:notification.id];
-        }
+        [self saveReadNotifications:self.readNotifications];
+        [self.messageList reloadData];
     }
-    
-    [self.messageList reloadData];
-    
     if (handleClick) {
-        handleClick(notification);
+        handleClick(self.notifications[indexPath.row]);
     }
 
-    if (notification.inboxAppBanner != nil && ![notification.inboxAppBanner isKindOfClass:[NSNull class]] )  {
-        [self showAppBanner:notification.inboxAppBanner notificationId:notification.id];
+    if (self.notifications[indexPath.row].inboxAppBanner != nil && ![self.notifications[indexPath.row].inboxAppBanner isKindOfClass:[NSNull class]] )  {
+        [self showAppBanner:self.notifications[indexPath.row].inboxAppBanner notificationId:self.notifications[indexPath.row].id];
     }
     
     [notification trackInboxClicked];
@@ -368,7 +359,9 @@ CPNotificationClickBlock handleClick;
                 NSMutableArray *topics = [NSMutableArray arrayWithArray:[CleverPush getSubscriptionTopics]];
                 for (NSString *topic in action.topics) {
                     if (![topics containsObject:topic]) {
-                        [topics addObject:topic];
+                        if (topic != nil && ![topic isKindOfClass:[NSNull class]] && [topic isKindOfClass:[NSString class]]) {
+                            [topics addObject:topic];
+                        }
                     }
                 }
                 [CleverPush setSubscriptionTopics:topics];

--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -219,7 +219,8 @@ CPNotificationClickBlock handleClick;
     if (self.notifications[indexPath.row].inboxAppBanner != nil && ![self.notifications[indexPath.row].inboxAppBanner isKindOfClass:[NSNull class]] )  {
         [self showAppBanner:self.notifications[indexPath.row].inboxAppBanner notificationId:self.notifications[indexPath.row].id];
     }
-    
+    CPNotification *notification = self.notifications[indexPath.row];
+    [notification setRead:YES];
     [notification trackInboxClicked];
 }
 

--- a/CleverPush/Source/CPNotificationCategoryController.m
+++ b/CleverPush/Source/CPNotificationCategoryController.m
@@ -21,7 +21,9 @@
 - (void)saveCategoryId:(NSString *)categoryId {
     NSMutableArray<NSString *> *mutableExisting = [self.existingRegisteredCategoryIds mutableCopy];
     
-    [mutableExisting addObject:categoryId];
+    if (categoryId != nil && ![categoryId isKindOfClass:[NSNull class]] && [categoryId isKindOfClass:[NSString class]]) {
+        [mutableExisting addObject:categoryId];
+    }
     
     if (mutableExisting && mutableExisting.count > MAX_CATEGORIES_SIZE) {
         [self pruneCategories:mutableExisting];
@@ -48,7 +50,9 @@
     NSMutableSet<NSString *> *categoriesToRemove = [NSMutableSet new];
     
     for (int i = (int)currentCategories.count - MAX_CATEGORIES_SIZE; i >= 0; i--) {
-        [categoriesToRemove addObject:currentCategories[i]];
+        if (currentCategories[i] != nil && ![currentCategories[i] isKindOfClass:[NSNull class]]) {
+            [categoriesToRemove addObject:currentCategories[i]];
+        }
     }
     NSMutableSet<UNNotificationCategory*>* existingCategories = self.existingCategories;
     NSMutableSet<UNNotificationCategory *> *newCategories = [NSMutableSet new];

--- a/CleverPush/Source/CPNotificationViewController.m
+++ b/CleverPush/Source/CPNotificationViewController.m
@@ -153,7 +153,10 @@
         images = [self.items mutableCopy];
         NSMutableArray *attachmentIDs = [[NSMutableArray alloc]init];
         for(UNNotificationAttachment *attachment in attachments) {
-            [attachmentIDs addObject:attachment.identifier];
+            NSString *identifier = attachment.identifier;
+            if (identifier != nil && ![identifier isKindOfClass:[NSNull class]] && [identifier isKindOfClass:[NSString class]]) {
+                [attachmentIDs addObject:identifier];
+            }
         }
         [self.carouselItems enumerateObjectsUsingBlock:
          ^(NSDictionary *image, NSUInteger index, BOOL *stop) {

--- a/CleverPush/Source/CPStoriesController.m
+++ b/CleverPush/Source/CPStoriesController.m
@@ -135,7 +135,9 @@
                                self.widget.id,
                                hasMultiplePages ? [NSString stringWithFormat:@"&#page=page-%ld", (long)subStoryIndex] : @""];
 
-        [storyURLs addObject:customURL];
+        if (customURL != nil && ![customURL isKindOfClass:[NSNull class]] && [customURL isKindOfClass:[NSString class]]) {
+            [storyURLs addObject:customURL];
+        }
     }
 
     NSError *error;
@@ -191,10 +193,14 @@
                 if (self.widget.groupStoryCategories) {
                     NSArray *currentStoryIds = [storyId componentsSeparatedByString:@","];
                     for (NSString *storyId in currentStoryIds) {
-                        [readStoryIdArray addObject:storyId];
+                        if (storyId != nil && ![storyId isKindOfClass:[NSNull class]] && [storyId isKindOfClass:[NSString class]]) {
+                            [readStoryIdArray addObject:storyId];
+                        }
                     }
                 } else {
-                    [readStoryIdArray addObject:storyId];
+                    if (storyId != nil && ![storyId isKindOfClass:[NSNull class]] && [storyId isKindOfClass:[NSString class]]) {
+                        [readStoryIdArray addObject:storyId];
+                    }
                 }
             }
 
@@ -374,7 +380,10 @@
 
 - (void)currentItemIndexDidChange:(NSInteger)index {
     if (![self.readStories containsObject:self.stories[index].id]) {
-        [self.readStories addObject:self.stories[index].id];
+        id storyId = self.stories[index].id;
+        if (storyId != nil && ![storyId isKindOfClass:[NSNull class]] && [storyId isKindOfClass:[NSString class]]) {
+            [self.readStories addObject:storyId];
+        }
         self.stories[index].opened = YES;
     }
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];

--- a/CleverPush/Source/CPStoryView.m
+++ b/CleverPush/Source/CPStoryView.m
@@ -627,7 +627,10 @@ CPStoryCell *previousAnimatedCell;
     [self animateCellBorder:cell];
     CPStoriesController* storiesController = [[CPStoriesController alloc] init];
     if (![self.readStories containsObject:self.stories[indexPath.item].id]) {
-        [self.readStories addObject:self.stories[indexPath.item].id];
+        id storyId = self.stories[indexPath.item].id;
+        if (storyId != nil && ![storyId isKindOfClass:[NSNull class]] && [storyId isKindOfClass:[NSString class]]) {
+            [self.readStories addObject:storyId];
+        }
         self.stories[indexPath.item].opened = YES;
     }
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
@@ -897,10 +900,14 @@ CPStoryCell *previousAnimatedCell;
           if (self.widget.groupStoryCategories) {
             NSArray *currentStoryIds = [storyIdString componentsSeparatedByString:@","];
             for (NSString *storyId in currentStoryIds) {
-              [storyIdArray addObject:storyId];
+              if (storyId != nil && ![storyId isKindOfClass:[NSNull class]] && [storyId isKindOfClass:[NSString class]]) {
+                  [storyIdArray addObject:storyId];
+              }
             }
           } else {
-            [storyIdArray addObject:storyIdString];
+            if (storyIdString != nil && ![storyIdString isKindOfClass:[NSNull class]] && [storyIdString isKindOfClass:[NSString class]]) {
+                [storyIdArray addObject:storyIdString];
+            }
           }
         }
       }

--- a/CleverPush/Source/CPTopicsViewController.m
+++ b/CleverPush/Source/CPTopicsViewController.m
@@ -175,7 +175,9 @@ static CGFloat const CPConstraints = 30.0;
         NSString* topicId = [topic id];
         BOOL contains = [selectedTopics containsObject:topicId];
         if (switcher.on && !contains) {
-            [selectedTopics addObject:topicId];
+            if (topicId != nil && ![topicId isKindOfClass:[NSNull class]] && [topicId isKindOfClass:[NSString class]]) {
+                [selectedTopics addObject:topicId];
+            }
         } else if ((!switcher.on && contains) || (switcher.on && contains) || (!switcher.on && !contains)) {
             [self setDefaultState:topicId];
         }

--- a/CleverPush/Source/CPUtils.m
+++ b/CleverPush/Source/CPUtils.m
@@ -953,13 +953,13 @@ NSString * const localeIdentifier = @"en_US_POSIX";
 + (NSArray<NSString *> *)fetchAssociatedDomains {
     NSMutableArray<NSString *> *domains = [NSMutableArray array];
     for (NSString *domain in [CleverPush getHandleUniversalLinksInAppForDomains]) {
-        NSString *trimmedDomain = domain;
+        if (domain != nil && ![domain isKindOfClass:[NSNull class]] && [domain isKindOfClass:[NSString class]]) {
+            NSString *trimmedDomain = domain;
 
-        if (![trimmedDomain hasPrefix:@"http://"] && ![trimmedDomain hasPrefix:@"https://"]) {
-            trimmedDomain = [NSString stringWithFormat:@"https://%@", trimmedDomain];
-        }
+            if (![trimmedDomain hasPrefix:@"http://"] && ![trimmedDomain hasPrefix:@"https://"]) {
+                trimmedDomain = [NSString stringWithFormat:@"https://%@", trimmedDomain];
+            }
 
-        if (trimmedDomain != nil && ![trimmedDomain isKindOfClass:[NSNull class]] && [trimmedDomain isKindOfClass:[NSString class]]) {
             [domains addObject:trimmedDomain];
         }
     }

--- a/CleverPush/Source/CPUtils.m
+++ b/CleverPush/Source/CPUtils.m
@@ -959,7 +959,9 @@ NSString * const localeIdentifier = @"en_US_POSIX";
             trimmedDomain = [NSString stringWithFormat:@"https://%@", trimmedDomain];
         }
 
-        [domains addObject:trimmedDomain];
+        if (trimmedDomain != nil && ![trimmedDomain isKindOfClass:[NSNull class]] && [trimmedDomain isKindOfClass:[NSString class]]) {
+            [domains addObject:trimmedDomain];
+        }
     }
 
     return [domains copy];

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -640,7 +640,10 @@ static id isNil(id object) {
             NSMutableArray* selectedTopicIds = [[NSMutableArray alloc] init];
             for (id channelTopic in channelTopics) {
                 if (channelTopic != nil && ([channelTopic objectForKey:@"defaultUnchecked"] == nil || ![[channelTopic objectForKey:@"defaultUnchecked"] boolValue])) {
-                    [selectedTopicIds addObject:[channelTopic objectForKey:@"_id"]];
+                    id topicId = [channelTopic objectForKey:@"_id"];
+                    if (topicId != nil && ![topicId isKindOfClass:[NSNull class]] && [topicId isKindOfClass:[NSString class]]) {
+                        [selectedTopicIds addObject:topicId];
+                    }
                 }
             }
             if ([selectedTopicIds count] > 0) {
@@ -1680,7 +1683,7 @@ static id isNil(id object) {
                 NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
                 NSMutableArray*arrTopics = [[NSMutableArray alloc] init];
                 [[results objectForKey:@"topics"] enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {
-                    if (![obj isKindOfClass:[NSNull class]]) {
+                    if (obj != nil && ![obj isKindOfClass:[NSNull class]] && [obj isKindOfClass:[NSString class]]) {
                         [arrTopics addObject:obj];
                     }
                 }];
@@ -2426,8 +2429,10 @@ static id isNil(id object) {
                     subscriptionTags = [[NSMutableArray alloc] init];
                 }
 
-                if (![subscriptionTags containsObject:tagId]) {
-                    [subscriptionTags addObject:tagId];
+                if (tagId != nil && ![tagId isKindOfClass:[NSNull class]] && [tagId isKindOfClass:[NSString class]]) {
+                    if (![subscriptionTags containsObject:tagId]) {
+                        [subscriptionTags addObject:tagId];
+                    }
                 }
                 NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
                 [userDefaults setObject:subscriptionTags forKey:CLEVERPUSH_SUBSCRIPTION_TAGS_KEY];
@@ -2653,8 +2658,10 @@ static id isNil(id object) {
                     } else {
                         arrayValue = [arrayValue mutableCopy];
                     }
-                    if (![arrayValue containsString:value]) {
-                        [arrayValue addObject:value];
+                    if (value != nil && ![value isKindOfClass:[NSNull class]] && [value isKindOfClass:[NSString class]]) {
+                        if (![arrayValue containsString:value]) {
+                            [arrayValue addObject:value];
+                        }
                     }
 
                     [subscriptionAttributes setObject:arrayValue forKey:attributeId];
@@ -2957,7 +2964,9 @@ static id isNil(id object) {
             return;
         }
         NSArray *originalTopics = [self getSubscriptionTopics];
-        [topics addObject:topicId];
+        if (topicId != nil && ![topicId isKindOfClass:[NSNull class]] && [topicId isKindOfClass:[NSString class]]) {
+            [topics addObject:topicId];
+        }
 
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
             NSMutableURLRequest* request = [[CleverPushHTTPClient sharedClient] requestWithMethod:HTTP_POST path:@"subscription/topic/add"];
@@ -3230,8 +3239,12 @@ static id isNil(id object) {
     NSMutableArray* subscriptionTopics = [self getSubscriptionTopics];
     NSMutableArray* dynamicQueryParameter = [NSMutableArray new];
     [subscriptionTopics enumerateObjectsUsingBlock: ^(id topic, NSUInteger index, BOOL*stop) {
-        NSString*queryParameter = [NSString stringWithFormat: @"topics[]=%@&", topic];
-        [dynamicQueryParameter addObject:queryParameter];
+        if (topic != nil && ![topic isKindOfClass:[NSNull class]]) {
+            NSString*queryParameter = [NSString stringWithFormat: @"topics[]=%@&", topic];
+            if (queryParameter != nil) {
+                [dynamicQueryParameter addObject:queryParameter];
+            }
+        }
     }];
     return dynamicQueryParameter;
 }
@@ -3250,9 +3263,11 @@ static id isNil(id object) {
     NSMutableArray* notificationIds = [NSMutableArray new];
     [notifications enumerateObjectsUsingBlock: ^(id objNotification, NSUInteger index, BOOL*stop) {
         NSString* notificationId = [objNotification objectForKey:@"_id"];
-        if (![notificationIds containsObject:notificationId]) {
-            [notificationIds addObject:notificationId];
-            [resultNotifications addObject:objNotification];
+        if (notificationId != nil && ![notificationId isKindOfClass:[NSNull class]] && [notificationId isKindOfClass:[NSString class]]) {
+            if (![notificationIds containsObject:notificationId]) {
+                [notificationIds addObject:notificationId];
+                [resultNotifications addObject:objNotification];
+            }
         }
     }];
     return resultNotifications;
@@ -3264,9 +3279,11 @@ static id isNil(id object) {
     NSMutableArray* notificationIds = [NSMutableArray new];
     [notifications enumerateObjectsUsingBlock: ^(id objNotification, NSUInteger index, BOOL*stop) {
         CPNotification*notification = [CPNotification initWithJson:objNotification];
-        if (![notificationIds containsObject:notification.id]) {
-            [notificationIds addObject:notification.id];
-            [resultNotifications addObject:notification];
+        if (notification != nil && notification.id != nil && ![notification.id isKindOfClass:[NSNull class]] && [notification.id isKindOfClass:[NSString class]]) {
+            if (![notificationIds containsObject:notification.id]) {
+                [notificationIds addObject:notification.id];
+                [resultNotifications addObject:notification];
+            }
         }
     }];
     return resultNotifications;


### PR DESCRIPTION
Optimized addObject to skip nil and NSNull values, ensuring only valid NSString objects are added and preventing potential crashes.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated all addObject calls to skip nil and NSNull values, making sure only valid NSString objects are added and preventing crashes from invalid data. This addresses the CP-9725 issue by improving data validation across the iOS SDK.

- **Bug Fixes**
 - Added checks before adding items to arrays to avoid NSInvalidArgumentException errors.
 - Improved stability when handling notification, banner, topic, and story IDs.

<!-- End of auto-generated description by cubic. -->

