### PR TITLE
hotfix/cp-9561-ios-mobile-sdk-call-the-api-created-to-communicate-and-track-v2

### DIFF
--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -204,20 +204,31 @@ CPNotificationClickBlock handleClick;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (![self.readNotifications containsObject:self.notifications[indexPath.row].id]) {
-        [self.readNotifications addObject:self.notifications[indexPath.row].id];
-        [self saveReadNotifications:self.readNotifications];
-        [self.messageList reloadData];
-    }
-    if (handleClick) {
-        handleClick(self.notifications[indexPath.row]);
-    }
-
-    if (self.notifications[indexPath.row].inboxAppBanner != nil && ![self.notifications[indexPath.row].inboxAppBanner isKindOfClass:[NSNull class]] )  {
-        [self showAppBanner:self.notifications[indexPath.row].inboxAppBanner notificationId:self.notifications[indexPath.row].id];
+    CPNotification *notification = self.notifications[indexPath.row];
+    BOOL isCurrentlyRead = [self.readNotifications containsObject:notification.id];
+    
+    if (!isCurrentlyRead) {
+        if (![self.readNotifications containsObject:notification.id]) {
+            [CleverPush setNotificationRead:notification.id read:true];
+            [self.readNotifications addObject:notification.id];
+        }
+    } else {
+        if ([self.readNotifications containsObject:notification.id]) {
+            [CleverPush setNotificationRead:notification.id read:false];
+            [self.readNotifications removeObject:notification.id];
+        }
     }
     
-    CPNotification *notification = self.notifications[indexPath.row];
+    [self.messageList reloadData];
+    
+    if (handleClick) {
+        handleClick(notification);
+    }
+
+    if (notification.inboxAppBanner != nil && ![notification.inboxAppBanner isKindOfClass:[NSNull class]] )  {
+        [self showAppBanner:notification.inboxAppBanner notificationId:notification.id];
+    }
+    
     [notification trackInboxClicked];
 }
 

--- a/CleverPush/Source/CPNotification.m
+++ b/CleverPush/Source/CPNotification.m
@@ -2,6 +2,7 @@
 #import "CPUtils.h"
 #import "NSDictionary+SafeExpectations.h"
 #import "CleverPushUserDefaults.h"
+#import "CleverPush.h"
 
 @implementation CPNotification
 #pragma mark - Initialise notifications by NSDictionary
@@ -125,41 +126,13 @@
     _read = read;
     
     if (read && self.id) {
-        NSUserDefaults *userDefaults = [CPUtils getUserDefaultsAppGroup];
-        if (!userDefaults) {
-            return;
-        }
-        
-        NSArray *readNotifications = [userDefaults arrayForKey:CLEVERPUSH_READ_NOTIFICATIONS_KEY];
-        NSMutableArray *updatedReadNotifications;
-        
-        if (readNotifications && [readNotifications isKindOfClass:[NSArray class]]) {
-            updatedReadNotifications = [readNotifications mutableCopy];
-        } else {
-            updatedReadNotifications = [[NSMutableArray alloc] init];
-        }
-        
-        if (![updatedReadNotifications containsObject:self.id]) {
-            [updatedReadNotifications addObject:self.id];
-            [userDefaults setObject:updatedReadNotifications forKey:CLEVERPUSH_READ_NOTIFICATIONS_KEY];
-            [userDefaults synchronize];
-        }
+        [CleverPush setNotificationRead:self.id read:read];
     }
 }
 
 - (BOOL)getRead {
-    NSUserDefaults *userDefaults = [CPUtils getUserDefaultsAppGroup];
-    if (!userDefaults) {
-        return _read;
-    }
-    
-    NSArray *readNotifications = [userDefaults arrayForKey:CLEVERPUSH_READ_NOTIFICATIONS_KEY];
-    if (readNotifications && [readNotifications isKindOfClass:[NSArray class]] && readNotifications.count > 0) {
-        if (self.id && [readNotifications containsObject:self.id]) {
-            return YES;
-        } else {
-            return _read;
-        }
+    if (self.id) {
+        return [CleverPush getNotificationRead:self.id];
     } else {
         return _read;
     }

--- a/CleverPush/Source/CleverPush.h
+++ b/CleverPush/Source/CleverPush.h
@@ -204,6 +204,8 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 + (void)removeNotification:(NSString* _Nullable)notificationId;
 + (void)removeNotification:(NSString* _Nullable)notificationId removeFromNotificationCenter:(BOOL)removeFromCenter;
 + (void)trackInboxClicked:(NSString* _Nullable)notificationId;
++ (void)setNotificationRead:(NSString* _Nullable)notificationId read:(BOOL)read;
++ (BOOL)getNotificationRead:(NSString* _Nullable)notificationId;
 
 + (NSArray<NSString*>* _Nullable)getSeenStories;
 + (NSArray<NSString*>* _Nullable)getHandleUniversalLinksInAppForDomains;

--- a/CleverPush/Source/CleverPush.m
+++ b/CleverPush/Source/CleverPush.m
@@ -845,6 +845,15 @@ static CleverPush* singleInstance = nil;
     [self.CPSharedInstance trackInboxClicked:notificationId];
 }
 
+#pragma mark - Notification Read Status Methods
++ (void)setNotificationRead:(NSString* _Nullable)notificationId read:(BOOL)read {
+    [self.CPSharedInstance setNotificationRead:notificationId read:read];
+}
+
++ (BOOL)getNotificationRead:(NSString* _Nullable)notificationId {
+    return [self.CPSharedInstance getNotificationRead:notificationId];
+}
+
 #pragma mark - Singleton shared instance of the cleverpush.
 + (CleverPush*)sharedInstance {
     @synchronized(singleInstance) {

--- a/CleverPush/Source/CleverPushInstance.h
+++ b/CleverPush/Source/CleverPushInstance.h
@@ -232,6 +232,8 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 - (void)removeNotification:(NSString* _Nullable)notificationId;
 - (void)removeNotification:(NSString* _Nullable)notificationId removeFromNotificationCenter:(BOOL)removeFromCenter;
 - (void)trackInboxClicked:(NSString* _Nullable)notificationId;
+- (void)setNotificationRead:(NSString* _Nullable)notificationId read:(BOOL)read;
+- (BOOL)getNotificationRead:(NSString* _Nullable)notificationId;
 - (void)setMaximumNotificationCount:(int)limit;
 - (void)getNotifications:(BOOL)combineWithApi callback:(void(^ _Nullable)(NSArray<CPNotification*>* _Nullable))callback;
 - (void)getNotifications:(BOOL)combineWithApi limit:(int)limit skip:(int)skip callback:(void(^ _Nullable)(NSArray<CPNotification*>* _Nullable))callback;

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1370,6 +1370,55 @@ static id isNil(id object) {
     return [[NSUserDefaults standardUserDefaults] boolForKey:CLEVERPUSH_UNSUBSCRIBED_KEY];
 }
 
+#pragma mark - Notification Read Status Methods
+- (void)setNotificationRead:(NSString* _Nullable)notificationId read:(BOOL)read {
+    if (!notificationId) {
+        return;
+    }
+    
+    NSUserDefaults *userDefaults = [CPUtils getUserDefaultsAppGroup];
+    if (!userDefaults) {
+        return;
+    }
+    
+    NSArray *readNotifications = [userDefaults arrayForKey:CLEVERPUSH_READ_NOTIFICATIONS_KEY];
+    NSMutableArray *updatedReadNotifications;
+    
+    if (readNotifications && [readNotifications isKindOfClass:[NSArray class]]) {
+        updatedReadNotifications = [readNotifications mutableCopy];
+    } else {
+        updatedReadNotifications = [[NSMutableArray alloc] init];
+    }
+    
+    if (read) {
+        if (![updatedReadNotifications containsObject:notificationId]) {
+            [updatedReadNotifications addObject:notificationId];
+            [userDefaults setObject:updatedReadNotifications forKey:CLEVERPUSH_READ_NOTIFICATIONS_KEY];
+            [userDefaults synchronize];
+        }
+    } else {
+        if ([updatedReadNotifications containsObject:notificationId]) {
+            [updatedReadNotifications removeObject:notificationId];
+            [userDefaults setObject:updatedReadNotifications forKey:CLEVERPUSH_READ_NOTIFICATIONS_KEY];
+            [userDefaults synchronize];
+        }
+    }
+}
+
+- (BOOL)getNotificationRead:(NSString* _Nullable)notificationId {
+    NSUserDefaults *userDefaults = [CPUtils getUserDefaultsAppGroup];
+    if (!userDefaults || !notificationId) {
+        return NO;
+    }
+    
+    NSArray *readNotifications = [userDefaults arrayForKey:CLEVERPUSH_READ_NOTIFICATIONS_KEY];
+    if (readNotifications && [readNotifications isKindOfClass:[NSArray class]] && readNotifications.count > 0) {
+        return [readNotifications containsObject:notificationId];
+    } else {
+        return NO;
+    }
+}
+
 #pragma mark - Clear the previous channel data from the NSUserDefaults on a fresh login and session expired.
 - (void)clearSubscriptionData {
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:CLEVERPUSH_SUBSCRIPTION_ID_KEY];


### PR DESCRIPTION
*  Added setNotificationRead and getNotificationRead methods and Optimized setRead and getRead to the CPNotification class to manage the read state of notifications.