### PR TITLE
hotfix/cp-9736-banner-does-not-trigger-with-deeplink

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1910,7 +1910,24 @@ static id isNil(id object) {
             [currentChatView loadChat];
         }
     }
-    if (notification != nil && [notification objectForKey:@"appBanner"] != nil && ![[notification objectForKey:@"appBanner"] isKindOfClass:[NSNull class]]) {
+    
+    BOOL hasValidUrl = notification != nil &&
+                       [notification objectForKey:@"url"] != nil &&
+                       ![[notification objectForKey:@"url"] isKindOfClass:[NSNull class]] &&
+                       [[notification objectForKey:@"url"] length] > 0 &&
+                       [CPUtils isValidURL:[NSURL URLWithString:[notification objectForKey:@"url"]]];
+
+    BOOL shouldAutoHandleDeepLink = notification != nil &&
+                                    [notification objectForKey:@"autoHandleDeepLink"] != nil &&
+                                    ![[notification objectForKey:@"autoHandleDeepLink"] isKindOfClass:[NSNull class]] &&
+                                    [[notification objectForKey:@"autoHandleDeepLink"] boolValue];
+
+    BOOL hasValidDeepLink = hasValidUrl && shouldAutoHandleDeepLink;
+    if (hasValidDeepLink) {
+        [CPAppBannerModuleInstance updateBannersForDeepLinkWithURL:[NSURL URLWithString:[notification objectForKey:@"url"]]];
+    }
+
+    if (notification != nil && [notification objectForKey:@"appBanner"] != nil && ![[notification objectForKey:@"appBanner"] isKindOfClass:[NSNull class]] && ![[notification objectForKey:@"appBanner"] isEqualToString:@""]) {
         if ([notification objectForKey:@"voucherCode"] != nil && ![[notification objectForKey:@"voucherCode"] isKindOfClass:[NSNull class]] && ![[notification objectForKey:@"voucherCode"] isEqualToString:@""]) {
             NSMutableDictionary*voucherCodesByAppBanner = [[NSMutableDictionary alloc] init];
             if ([CPAppBannerModuleInstance getCurrentVoucherCodePlaceholder] != nil && [CPAppBannerModuleInstance getCurrentVoucherCodePlaceholder].count > 0) {
@@ -1929,14 +1946,8 @@ static id isNil(id object) {
         notification = [payloadMutable cleverPushDictionaryForKey:@"notification"];
     }
 
-    if (notification != nil && [notification objectForKey:@"url"] != nil && ![[notification objectForKey:@"url"] isKindOfClass:[NSNull class]] && [[notification objectForKey:@"url"] length] != 0) {
-        NSURL*url = [NSURL URLWithString:[notification objectForKey:@"url"]];
-        if ([notification objectForKey:@"autoHandleDeepLink"] != nil && ![[notification objectForKey:@"autoHandleDeepLink"] isKindOfClass:[NSNull class]] && [[notification objectForKey:@"autoHandleDeepLink"] boolValue]) {
-            if ([CPUtils isValidURL:url]) {
-                [CPAppBannerModuleInstance updateBannersForDeepLinkWithURL:url];
-                [CPUtils tryOpenURL:url];
-            }
-        }
+    if (hasValidDeepLink) {
+        [CPUtils tryOpenURL:[NSURL URLWithString:[notification objectForKey:@"url"]]];
     }
 
     CPNotificationOpenedResult* result = [[CPNotificationOpenedResult alloc] initWithPayload:payloadMutable action:action];


### PR DESCRIPTION
Resolved the issue of appBanners were not displaying with the deepLink.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes CP-9736: app banners now trigger when a notification opens a deep link with autoHandleDeepLink enabled. We validate the URL, update banners for the deep link, then open the URL.

- **Bug Fixes**
  - Add a single hasValidDeepLink check (valid URL + autoHandleDeepLink) used for both banner update and URL open.
  - Trigger updateBannersForDeepLinkWithURL before tryOpenURL, and ignore empty appBanner values.

<!-- End of auto-generated description by cubic. -->

