### PR TITLE
feature/cp-9794-ios-implement-sync-subscription-logic-for-tags

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1695,6 +1695,18 @@ static id isNil(id object) {
                 [userDefaults synchronize];
             }
 
+                NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+                NSMutableArray*arrTags = [[NSMutableArray alloc] init];
+                [[results objectForKey:@"tags"] enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {
+                    if (obj != nil && ![obj isKindOfClass:[NSNull class]] && [obj isKindOfClass:[NSString class]]) {
+                        [arrTags addObject:obj];
+                    }
+                }];
+                
+                [userDefaults setObject:arrTags forKey:CLEVERPUSH_SUBSCRIPTION_TAGS_KEY];
+                [userDefaults synchronize];
+            }
+            
             if ([results objectForKey:@"id"] != nil) {
                 NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
                 if (!subscriptionId) {

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1695,6 +1695,7 @@ static id isNil(id object) {
                 [userDefaults synchronize];
             }
 
+            if ([results objectForKey:@"tags"] != nil) {
                 NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
                 NSMutableArray*arrTags = [[NSMutableArray alloc] init];
                 [[results objectForKey:@"tags"] enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {


### PR DESCRIPTION
Added support for syncing subscription tags from the backend to local.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Implements Linear CP-9794 by syncing subscription tags from /subscription/sync to NSUserDefaults (CLEVERPUSH_SUBSCRIPTION_TAGS_KEY). Filters to valid string tags before saving.

<!-- End of auto-generated description by cubic. -->

