### PR TITLE
hotfix/cp-9864-banner-leads-to-app-crashes

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -1263,6 +1263,9 @@ int appBannerPerDayValue = 0;
             NSString *voucherCode;
             
             if (handleBannerOpened && action) {
+                if (action && action.url && ([action.url.absoluteString isEqualToString:@""] || [action.url.absoluteString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length == 0)) {
+                    action.url = nil;
+                }
                 handleBannerOpened(action);
             }
 


### PR DESCRIPTION
Set action.url to nil when it's an empty string before calling the setAppBannerOpenedCallback.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevent app crash when opening banners by setting action.url to nil if it’s empty or whitespace before calling setAppBannerOpenedCallback. Addresses Linear CP-9864 where banners with blank URLs triggered a crash.

<!-- End of auto-generated description by cubic. -->

