### PR TITLE
hotfix/cp-9943-ios-sdk-optimized-title-fallback-logic-in-story-view

### DIFF
--- a/CleverPush/Source/CPStoryView.m
+++ b/CleverPush/Source/CPStoryView.m
@@ -506,11 +506,23 @@ CPStoryCell *previousAnimatedCell;
     [cell.image setImageWithURL:imageURL];
 
     if (self.titleVisibility) {
+        CPStory *story = self.stories[indexPath.item];
+        NSString *titleText = @"";
+
         if (self.widget.groupStoryCategories) {
-            cell.name.text = self.stories[indexPath.item].content.subtitle;
+            if (story.content.subtitle != nil && story.content.subtitle.length > 0) {
+                titleText = story.content.subtitle;
+            } else if (story.content.title != nil && story.content.title.length > 0) {
+                titleText = story.content.title;
+            }
         } else {
-            cell.name.text = self.stories[indexPath.item].title;
+            if (story.title != nil && story.title.length > 0) {
+                titleText = story.title;
+            } else if (story.content.title != nil && story.content.title.length > 0) {
+                titleText = story.content.title;
+            }
         }
+        cell.name.text = titleText;
         cell.name.textColor = self.textColor;
         if (darkModeEnabled) {
             cell.name.textColor = self.textColorDarkMode;


### PR DESCRIPTION
If the story's title is missing, we now check content.title as a fallback. ( Same like Android )
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a robust title fallback in StoryView to prevent blank names: when grouped, prefer content.subtitle then content.title; otherwise use story.title then content.title. Aligns iOS with Android (CP-9943).

<!-- End of auto-generated description by cubic. -->

