### PR TITLE
feature/cp-11108-ios-implement-method-for-marking-subscription-as-test

### DIFF
--- a/CleverPush/Source/CleverPush.h
+++ b/CleverPush/Source/CleverPush.h
@@ -94,6 +94,8 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 + (void)unsubscribe;
 + (void)unsubscribe:(void(^ _Nullable)(BOOL))callback;
 + (void)syncSubscription;
++ (void)markSubscriptionAsTest;
++ (void)markSubscriptionAsTestOnSuccess:(CPResultSuccessBlock _Nullable)successBlock onFailure:(CPFailureBlock _Nullable)failureBlock;
 + (void)didRegisterForRemoteNotifications:(UIApplication* _Nullable)app deviceToken:(NSData* _Nullable)inDeviceToken;
 + (void)handleDidFailRegisterForRemoteNotification:(NSError* _Nullable)err;
 + (void)handleNotificationOpened:(NSDictionary* _Nullable)messageDict isActive:(BOOL)isActive actionIdentifier:(NSString* _Nullable)actionIdentifier;

--- a/CleverPush/Source/CleverPush.m
+++ b/CleverPush/Source/CleverPush.m
@@ -244,6 +244,14 @@ static CleverPush* singleInstance = nil;
     [self.CPSharedInstance syncSubscription];
 }
 
++ (void)markSubscriptionAsTest {
+    [self.CPSharedInstance markSubscriptionAsTest];
+}
+
++ (void)markSubscriptionAsTestOnSuccess:(CPResultSuccessBlock _Nullable)successBlock onFailure:(CPFailureBlock _Nullable)failureBlock {
+    [self.CPSharedInstance markSubscriptionAsTestOnSuccess:successBlock onFailure:failureBlock];
+}
+
 + (void)didRegisterForRemoteNotifications:(UIApplication* _Nullable)app deviceToken:(NSData* _Nullable)inDeviceToken {
     [self.CPSharedInstance didRegisterForRemoteNotifications:app deviceToken:inDeviceToken];
 }

--- a/CleverPush/Source/CleverPushInstance.h
+++ b/CleverPush/Source/CleverPushInstance.h
@@ -129,6 +129,8 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 - (void)syncSubscription;
 - (void)syncSubscription:(CPFailureBlock _Nullable)failureBlock;
 - (void)syncSubscription:(CPFailureBlock _Nullable)failureBlock successBlock:(void(^)())successBlock;
+- (void)markSubscriptionAsTest;
+- (void)markSubscriptionAsTestOnSuccess:(CPResultSuccessBlock _Nullable)successBlock onFailure:(CPFailureBlock _Nullable)failureBlock;
 - (void)didRegisterForRemoteNotifications:(UIApplication* _Nullable)app deviceToken:(NSData* _Nullable)inDeviceToken;
 - (void)handleDidFailRegisterForRemoteNotification:(NSError* _Nullable)err;
 - (void)handleNotificationOpened:(NSDictionary* _Nullable)messageDict isActive:(BOOL)isActive actionIdentifier:(NSString* _Nullable)actionIdentifier;

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1534,6 +1534,53 @@ static id isNil(id object) {
     }
 }
 
+- (void)markSubscriptionAsTest {
+    [self markSubscriptionAsTestOnSuccess:nil onFailure:nil];
+}
+
+- (void)markSubscriptionAsTestOnSuccess:(CPResultSuccessBlock _Nullable)successBlock onFailure:(CPFailureBlock _Nullable)failureBlock {
+    if (channelId == nil) {
+        channelId = [self getChannelIdFromUserDefaults];
+    }
+    if (channelId == nil || [channelId length] == 0) {
+        [CPLog warn:@"markSubscriptionAsTest: Channel ID is null"];
+        if (failureBlock) {
+            failureBlock([NSError errorWithDomain:@"com.cleverpush" code:400 userInfo:@{NSLocalizedDescriptionKey:@"Channel ID is null or empty"}]);
+        }
+        return;
+    }
+    [self getSubscriptionId:^(NSString*subscriptionId) {
+        if (subscriptionId == nil || [subscriptionId length] == 0) {
+            [CPLog warn:@"markSubscriptionAsTest: There is no subscriptionId"];
+            if (failureBlock) {
+                failureBlock([NSError errorWithDomain:@"com.cleverpush" code:400 userInfo:@{NSLocalizedDescriptionKey:@"Subscription ID is null or empty"}]);
+            }
+            return;
+        }
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
+            NSMutableURLRequest* request = [[CleverPushHTTPClient sharedClient] requestWithMethod:HTTP_POST path:@"subscription/mark-as-test"];
+            NSDictionary* dataDic = [NSDictionary dictionaryWithObjectsAndKeys:
+                                     channelId, @"channelId",
+                                     subscriptionId, @"subscriptionId",
+                                     nil];
+
+            NSData* postData = [NSJSONSerialization dataWithJSONObject:dataDic options:0 error:nil];
+            [request setHTTPBody:postData];
+            [self enqueueRequest:request onSuccess:^(NSDictionary* results) {
+                [CPLog debug:@"markSubscriptionAsTest: Successfully marked subscription as test"];
+                if (successBlock) {
+                    successBlock(results);
+                }
+            } onFailure:^(NSError* error) {
+                [CPLog error:@"markSubscriptionAsTest: Failed to mark subscription as test. %@", error];
+                if (failureBlock) {
+                    failureBlock(error);
+                }
+            }];
+        });
+    }];
+}
+
 #pragma mark - identify the channels being subscribed or not
 - (BOOL)isSubscribed {
     if (subscriptionId) {


### PR DESCRIPTION
Added method markSubscriptionAsTest to mark subscription as test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements an iOS API to mark the current subscription as a test, addressing CP-11108. Adds convenience and callback methods that POST to the backend to flag the subscription.

- **New Features**
  - Adds `CleverPush.markSubscriptionAsTest()` and `CleverPush.markSubscriptionAsTest(onSuccess:onFailure:)` (with matching instance methods).
  - Validates `channelId` and `subscriptionId`; fails with an error if missing.
  - Sends POST to `subscription/mark-as-test`; triggers success/failure callbacks and logs results.

<sup>Written for commit d584d01d5740beef8ee1e6beebb4c627861bf698. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

