### PR TITLE
hotfix/cp-11342-ios-sdk-optimize-uiapplicationdelegatecleverpush-class-for

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -1991,20 +1991,24 @@ int appBannerPerDayValue = 0;
 
 #pragma mark - get app banner ids from silent push
 - (void)showPendingSilentPushAppBannersIds:(NSString*)channelId {
-	NSMutableArray *appBanners = [[[NSUserDefaults standardUserDefaults] objectForKey:CLEVERPUSH_SILENT_PUSH_APP_BANNERS_KEY] mutableCopy];
-	if (appBanners != nil && appBanners.count > 0) {
-		NSMutableArray *objectsToRemove = [[NSMutableArray alloc] init];
-
-		for (NSMutableDictionary *eventsObject in appBanners) {
-			[self showBanner:channelId bannerId:[eventsObject objectForKey:@"appBanner"] notificationId:[eventsObject objectForKey:@"notificationId"] force:NO];
-			[objectsToRemove addObject:eventsObject];
-		}
-
-		[appBanners removeObjectsInArray:objectsToRemove];
-
-		[[NSUserDefaults standardUserDefaults] removeObjectForKey:CLEVERPUSH_SILENT_PUSH_APP_BANNERS_KEY];
-		[[NSUserDefaults standardUserDefaults] synchronize];
-	}
+    NSMutableArray *appBanners = [[[NSUserDefaults standardUserDefaults] objectForKey:CLEVERPUSH_SILENT_PUSH_APP_BANNERS_KEY] mutableCopy];
+    if (appBanners == nil || appBanners.count == 0) {
+        return;
+    }
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive) {
+            return;
+        }
+        NSMutableArray *objectsToRemove = [[NSMutableArray alloc] init];
+        for (NSMutableDictionary *eventsObject in appBanners) {
+            [self showBanner:channelId bannerId:[eventsObject objectForKey:@"appBanner"] notificationId:[eventsObject objectForKey:@"notificationId"] force:NO];
+            [objectsToRemove addObject:eventsObject];
+        }
+        [appBanners removeObjectsInArray:objectsToRemove];
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:CLEVERPUSH_SILENT_PUSH_APP_BANNERS_KEY];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    });
 }
 
 #pragma mark - Get the value of pageControl from current index

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1919,6 +1919,8 @@ static id isNil(id object) {
     }
 
     if (!handleNotificationReceived) {
+        CPNotificationReceivedResult* pending = [[CPNotificationReceivedResult alloc] initWithPayload:messageDict];
+        pendingDeliveryResult = pending;
         return;
     }
 

--- a/CleverPush/Source/UIApplicationDelegate+CleverPush.m
+++ b/CleverPush/Source/UIApplicationDelegate+CleverPush.m
@@ -181,7 +181,10 @@ static NSMutableSet<Class>* swizzledClasses;
 
 - (BOOL)cleverPushReceivedDidFinishLaunching:(UIApplication *)application
                                launchOptions:(NSDictionary *)launchOptions {
-    BOOL result = [self cleverPushReceivedDidFinishLaunching:application launchOptions:launchOptions];
+    BOOL result = YES;
+    if ([self respondsToSelector:@selector(cleverPushReceivedDidFinishLaunching:launchOptions:)]) {
+        result = [self cleverPushReceivedDidFinishLaunching:application launchOptions:launchOptions];
+    }
     NSDictionary *remoteNotif = launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
     if (remoteNotif && [CleverPush channelId]) {
         [CleverPush handleSilentNotificationReceived:application

--- a/CleverPush/Source/UIApplicationDelegate+CleverPush.m
+++ b/CleverPush/Source/UIApplicationDelegate+CleverPush.m
@@ -32,6 +32,60 @@ static NSMutableSet<Class>* swizzledClasses;
     return delegateClass;
 }
 
++ (BOOL)classDefinesSelector:(SEL)sel directlyOnClass:(Class)cls {
+    unsigned int count = 0;
+    Method *methods = class_copyMethodList(cls, &count);
+    BOOL found = NO;
+    for (unsigned int i = 0; i < count; i++) {
+        if (method_getName(methods[i]) == sel) {
+            found = YES;
+            break;
+        }
+    }
+    free(methods);
+    return found;
+}
+
++ (void)injectSilentNotificationHandlerInto:(Class)delegateClass {
+    SEL targetSel = @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:);
+    SEL cpSel     = @selector(cleverPushReceivedSilentRemoteNotification:UserInfo:fetchCompletionHandler:);
+    Class cpClass = [CleverPushAppDelegate class];
+
+    if ([CleverPushAppDelegate classDefinesSelector:targetSel directlyOnClass:delegateClass]) {
+        injectSelector(delegateClass, targetSel, cpClass, cpSel);
+        return;
+    }
+
+    Method inheritedMeth = class_getInstanceMethod(delegateClass, targetSel);
+    if (inheritedMeth) {
+        class_addMethod(delegateClass,
+                        targetSel,
+                        method_getImplementation(inheritedMeth),
+                        method_getTypeEncoding(inheritedMeth));
+    }
+    injectSelector(delegateClass, targetSel, cpClass, cpSel);
+}
+
++ (void)injectLaunchOptionsHandlerInto:(Class)delegateClass {
+    SEL targetSel = @selector(application:didFinishLaunchingWithOptions:);
+    SEL cpSel     = @selector(cleverPushReceivedDidFinishLaunching:launchOptions:);
+    Class cpClass = [CleverPushAppDelegate class];
+
+    if ([CleverPushAppDelegate classDefinesSelector:targetSel directlyOnClass:delegateClass]) {
+        injectSelector(delegateClass, targetSel, cpClass, cpSel);
+        return;
+    }
+
+    Method inheritedMeth = class_getInstanceMethod(delegateClass, targetSel);
+    if (inheritedMeth) {
+        class_addMethod(delegateClass,
+                        targetSel,
+                        method_getImplementation(inheritedMeth),
+                        method_getTypeEncoding(inheritedMeth));
+    }
+    injectSelector(delegateClass, targetSel, cpClass, cpSel);
+}
+
 - (void)setCleverPushDelegate:(id<UIApplicationDelegate>)delegate {
     if (swizzledClasses == nil) {
         swizzledClasses = [NSMutableSet new];
@@ -47,7 +101,8 @@ static NSMutableSet<Class>* swizzledClasses;
     Class newClass = [CleverPushAppDelegate class];
     delegateClass = [delegate class];
 
-    injectSelector(delegateClass, @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:), newClass, @selector(cleverPushReceivedSilentRemoteNotification:UserInfo:fetchCompletionHandler:));
+    [CleverPushAppDelegate injectSilentNotificationHandlerInto:delegateClass];
+    [CleverPushAppDelegate injectLaunchOptionsHandlerInto:delegateClass];
 
     [CleverPushAppDelegate injectPreiOS10MethodsPhase1];
 
@@ -122,6 +177,18 @@ static NSMutableSet<Class>* swizzledClasses;
     if ([self respondsToSelector:@selector(cleverPushReceivedRemoteNotification:userInfo:)]) {
         [self cleverPushReceivedRemoteNotification:application userInfo:userInfo];
     }
+}
+
+- (BOOL)cleverPushReceivedDidFinishLaunching:(UIApplication *)application
+                               launchOptions:(NSDictionary *)launchOptions {
+    BOOL result = [self cleverPushReceivedDidFinishLaunching:application launchOptions:launchOptions];
+    NSDictionary *remoteNotif = launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
+    if (remoteNotif && [CleverPush channelId]) {
+        [CleverPush handleSilentNotificationReceived:application
+                                            UserInfo:remoteNotif
+                                   completionHandler:nil];
+    }
+    return result;
 }
 
 - (void)cleverPushReceivedSilentRemoteNotification:(UIApplication*)application UserInfo:(NSDictionary*)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult)) completionHandler {


### PR DESCRIPTION
optimized uiapplicationdelegatecleverpush class for silent push notifications

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves silent push handling by making delegate injection more robust and processing notifications at app launch. This addresses CP-11342 and ensures banners from silent pushes only show on the main thread when the app is active.

- **Bug Fixes**
  - Reliably injects `application:didReceiveRemoteNotification:fetchCompletionHandler:` and `application:didFinishLaunchingWithOptions:` even when inherited.
  - Processes silent pushes from `UIApplicationLaunchOptionsRemoteNotificationKey` on cold start.
  - Queues `pendingDeliveryResult` when the SDK isn’t ready to avoid lost events.
  - Shows silent-push app banners only on the main thread and when the app is active; otherwise skips and cleans stored entries.

<sup>Written for commit 7355af18735c34cdf8c908d3016191a53565ae66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

