### PR TITLE
feature/cp-10601-make-banner-non-blocking

### DIFF
--- a/CleverPush.xcodeproj/project.pbxproj
+++ b/CleverPush.xcodeproj/project.pbxproj
@@ -32,6 +32,10 @@
 		2905218B276B8BC600D81148 /* CleverPushInstance.m in Sources */ = {isa = PBXBuildFile; fileRef = CB1B65C52757763B0087AC49 /* CleverPushInstance.m */; };
 		2905218C276B8C6500D81148 /* CPAppBannerModuleInstance.h in Headers */ = {isa = PBXBuildFile; fileRef = CB1B65FB2757815C0087AC49 /* CPAppBannerModuleInstance.h */; };
 		2905218D276B8C6700D81148 /* CPAppBannerModuleInstance.m in Sources */ = {isa = PBXBuildFile; fileRef = CB1B65FC2757815C0087AC49 /* CPAppBannerModuleInstance.m */; };
+
+		AA00002100000000000000AA /* CPAppBannerPassthroughView.h in Headers */ = {isa = PBXBuildFile; fileRef = AA00002000000000000000AA /* CPAppBannerPassthroughView.h */; };
+		AA00002200000000000000AA /* CPAppBannerPassthroughView.m in Sources */ = {isa = PBXBuildFile; fileRef = AA00002300000000000000AA /* CPAppBannerPassthroughView.m */; };
+		AA00002400000000000000AA /* CPAppBannerPassthroughView.m in Sources */ = {isa = PBXBuildFile; fileRef = AA00002300000000000000AA /* CPAppBannerPassthroughView.m */; };
 		2906A0992585546F0078FD61 /* CPAppBannerModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 2986766F2572CC340002E9F1 /* CPAppBannerModule.h */; };
 		2906A1022585575D0078FD61 /* CPAppBanner.h in Headers */ = {isa = PBXBuildFile; fileRef = 298676B52572CFE50002E9F1 /* CPAppBanner.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2906A10B258557610078FD61 /* CPAppBannerDismissType.h in Headers */ = {isa = PBXBuildFile; fileRef = 298676CA2572CFFF0002E9F1 /* CPAppBannerDismissType.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -242,6 +246,7 @@
 		93D458332B3598C4000F4A80 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93D458322B3598C4000F4A80 /* ImageIO.framework */; };
 		93D458352B3599D9000F4A80 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93D458342B3599D9000F4A80 /* MobileCoreServices.framework */; };
 		93DACB1C2959651900177B08 /* CPAppBannerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CB73FFAC272C44720099B648 /* CPAppBannerViewController.xib */; };
+
 		93DACB1D2959651900177B08 /* CPTextBlockCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CB73FF88272C3E200099B648 /* CPTextBlockCell.xib */; };
 		93DACB1E2959651900177B08 /* CPImageBlockCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CB73FF87272C3E150099B648 /* CPImageBlockCell.xib */; };
 		93DACB1F2959651900177B08 /* CPHTMLBlockCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CB73FF86272C3E060099B648 /* CPHTMLBlockCell.xib */; };
@@ -621,6 +626,9 @@
 		CB1B65F9275780260087AC49 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		CB1B65FB2757815C0087AC49 /* CPAppBannerModuleInstance.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CPAppBannerModuleInstance.h; sourceTree = "<group>"; };
 		CB1B65FC2757815C0087AC49 /* CPAppBannerModuleInstance.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CPAppBannerModuleInstance.m; sourceTree = "<group>"; };
+
+		AA00002000000000000000AA /* CPAppBannerPassthroughView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CPAppBannerPassthroughView.h; sourceTree = "<group>"; };
+		AA00002300000000000000AA /* CPAppBannerPassthroughView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CPAppBannerPassthroughView.m; sourceTree = "<group>"; };
 		CB73FF82272C3D850099B648 /* CPBannerCardContainer.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CPBannerCardContainer.xib; sourceTree = "<group>"; };
 		CB73FF83272C3D920099B648 /* CPButtonBlockCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CPButtonBlockCell.xib; sourceTree = "<group>"; };
 		CB73FF86272C3E060099B648 /* CPHTMLBlockCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CPHTMLBlockCell.xib; sourceTree = "<group>"; };
@@ -641,6 +649,7 @@
 		CB73FFA7272C44610099B648 /* CPAppBannerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPAppBannerViewController.h; sourceTree = "<group>"; };
 		CB73FFA8272C44610099B648 /* CPAppBannerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CPAppBannerViewController.m; sourceTree = "<group>"; };
 		CB73FFAC272C44720099B648 /* CPAppBannerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CPAppBannerViewController.xib; sourceTree = "<group>"; };
+
 		CB79117B2667558F00253F9F /* CPAppBannerHTMLBlock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CPAppBannerHTMLBlock.h; sourceTree = "<group>"; };
 		CB79117C2667558F00253F9F /* CPAppBannerHTMLBlock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CPAppBannerHTMLBlock.m; sourceTree = "<group>"; };
 		CB8129ED267B6F3B002B8A3D /* CPWKWebView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CPWKWebView.h; sourceTree = "<group>"; };
@@ -875,6 +884,7 @@
 			isa = PBXGroup;
 			children = (
 				CB73FFAC272C44720099B648 /* CPAppBannerViewController.xib */,
+
 				CB73FF88272C3E200099B648 /* CPTextBlockCell.xib */,
 				CB73FF87272C3E150099B648 /* CPImageBlockCell.xib */,
 				CB73FF86272C3E060099B648 /* CPHTMLBlockCell.xib */,
@@ -935,6 +945,9 @@
 				298676702572CC400002E9F1 /* CPAppBannerModule.m */,
 				CB1B65FB2757815C0087AC49 /* CPAppBannerModuleInstance.h */,
 				CB1B65FC2757815C0087AC49 /* CPAppBannerModuleInstance.m */,
+
+				AA00002000000000000000AA /* CPAppBannerPassthroughView.h */,
+				AA00002300000000000000AA /* CPAppBannerPassthroughView.m */,
 				93DBD4182C37C65A001CB7ED /* CPAppBannerNotificationPermission.h */,
 				298676E02572D0340002E9F1 /* CPAppBannerStatus.h */,
 				298676E12572D0400002E9F1 /* CPAppBannerStopAtType.h */,
@@ -1245,6 +1258,8 @@
 				CBA989B32679D664003DE995 /* CPWidgetPosition.h in Headers */,
 				2906A16D258557C20078FD61 /* CPAppBannerImageBlock.h in Headers */,
 				2905218C276B8C6500D81148 /* CPAppBannerModuleInstance.h in Headers */,
+
+				AA00002100000000000000AA /* CPAppBannerPassthroughView.h in Headers */,
 				93C8FA3E2C5B924F00300B69 /* CPStoryWidgetCloseButtonPosition.h in Headers */,
 				290187F627C1020200535617 /* CleverPushUserDefaults.h in Headers */,
 			);
@@ -1465,6 +1480,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				93DACB1C2959651900177B08 /* CPAppBannerViewController.xib in Resources */,
+
 				937390BB2BAD87A000ADFA78 /* PrivacyInfo.xcprivacy in Resources */,
 				93DACB1D2959651900177B08 /* CPTextBlockCell.xib in Resources */,
 				939E9C702CE76E5500DE7293 /* CPStoryPlayerHtmlContent.html in Resources */,
@@ -1556,6 +1572,8 @@
 				CBA989A52679D628003DE995 /* CPWidgetModule.m in Sources */,
 				291FCECA252B65E200F5185E /* DWAlertPresentationController.m in Sources */,
 				2905218D276B8C6700D81148 /* CPAppBannerModuleInstance.m in Sources */,
+
+				AA00002200000000000000AA /* CPAppBannerPassthroughView.m in Sources */,
 				298F4FC525002F1F00F086D3 /* CPUtils.m in Sources */,
 				297B4E291E58A16600BAF990 /* CleverPushHTTPClient.m in Sources */,
 				CB73FF92272C3E8A0099B648 /* CPButtonBlockCell.m in Sources */,
@@ -1649,6 +1667,8 @@
 				296A134325BE128700A2BEED /* CPSubscription.m in Sources */,
 				296A136225BE16CF00A2BEED /* CPChannelTag.m in Sources */,
 				CB1B65FD2757815C0087AC49 /* CPAppBannerModuleInstance.m in Sources */,
+
+				AA00002400000000000000AA /* CPAppBannerPassthroughView.m in Sources */,
 				296068902574452B002159D0 /* CPAspectKeepImageView.m in Sources */,
 				29D22E71252C8E7500977567 /* CPIntrinsicTableView.m in Sources */,
 				CB73FF95272C3E970099B648 /* CPHTMLBlockCell.m in Sources */,

--- a/CleverPush/Source/CPAppBannerModule.h
+++ b/CleverPush/Source/CPAppBannerModule.h
@@ -40,6 +40,7 @@
 + (void)disableBanners;
 + (void)enableBanners;
 + (void)setTrackingEnabled:(BOOL)enabled;
++ (void)setAppBannersNonBlocking:(BOOL)nonBlocking;
 + (void)resetInitialization;
 + (void)setCurrentEventId:(NSString*)eventId;
 + (void)sendBannerEvent:(NSString*)event forBanner:(CPAppBanner*)banner forScreen:(CPAppBannerCarouselBlock*)screen forButtonBlock:(CPAppBannerButtonBlock*)button forImageBlock:(CPAppBannerImageBlock*)image blockType:(NSString*)type;

--- a/CleverPush/Source/CPAppBannerModule.m
+++ b/CleverPush/Source/CPAppBannerModule.m
@@ -170,6 +170,10 @@ static CPAppBannerModuleInstance* singletonInstance = nil;
     [self.moduleInstance setTrackingEnabled:enabled];
 }
 
++ (void)setAppBannersNonBlocking:(BOOL)nonBlocking {
+    [self.moduleInstance setAppBannersNonBlocking:nonBlocking];
+}
+
 + (void)setCurrentEventId:(NSString*)eventId {
     [self.moduleInstance setCurrentEventId:eventId];
 }

--- a/CleverPush/Source/CPAppBannerModuleInstance.h
+++ b/CleverPush/Source/CPAppBannerModuleInstance.h
@@ -65,6 +65,7 @@
 - (void)disableBanners;
 - (void)enableBanners;
 - (void)setTrackingEnabled:(BOOL)enabled;
+- (void)setAppBannersNonBlocking:(BOOL)nonBlocking;
 - (void)setCurrentEventId:(NSString*)eventId;
 
 #pragma mark - refactor for testcases

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -1,4 +1,5 @@
 #import "CPAppBannerModuleInstance.h"
+#import "CPAppBannerPassthroughView.h"
 #import "CPUtils.h"
 #import "CPLog.h"
 #import "NSDictionary+SafeExpectations.h"
@@ -29,7 +30,7 @@ CPAppBannerShownBlock handleBannerShown;
 CPAppBannerClosedBlock handleBannerClosed;
 CPSQLiteManager *sqlManager;
 CPAppBannerDisplayBlock handleBannerDisplayed;
-
+CPAppBannerPassthroughView *activeBannerOverlay;
 
 static NSObject *callbackLock;
 static NSObject *bannerRequestLock;
@@ -39,6 +40,7 @@ BOOL pendingBannerRequest = NO;
 BOOL bannersDisabled = NO;
 BOOL isFromNotification = NO;
 BOOL trackingEnabled = YES;
+BOOL appBannersNonBlocking = NO;
 
 long MIN_SESSION_LENGTH = 30 * 60;
 long MIN_SESSION_LENGTH_DEV = 30;
@@ -1613,8 +1615,6 @@ int appBannerPerDayValue = 0;
 
     [[NSUserDefaults standardUserDefaults] setBool:true forKey:CLEVERPUSH_APP_BANNER_VISIBLE_KEY];
     [[NSUserDefaults standardUserDefaults] synchronize];
-    [appBannerViewController setModalPresentationStyle:[CleverPush getAppBannerModalPresentationStyle]];
-    [appBannerViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
     appBannerViewController.data = banner;
 
     CPAppBannerClosedBlock closedCallback = nil;
@@ -1626,8 +1626,7 @@ int appBannerPerDayValue = 0;
     }
     
     [CPAppBannerViewController preloadImagesForBanner:banner];
-    UIViewController* topController = [CleverPush topViewController];
-    
+
     CPAppBannerDisplayBlock displayCallback = nil;
     @synchronized(callbackLock) {
         displayCallback = handleBannerDisplayed;
@@ -1635,22 +1634,10 @@ int appBannerPerDayValue = 0;
     
     if (displayCallback) {
         displayCallback(appBannerViewController);
+    } else if (appBannersNonBlocking) {
+        [self presentNonBlockingBanner:appBannerViewController banner:banner notificationId:notificationId force:force];
     } else {
-        if (!force && [CPUtils isNullOrEmpty:notificationId]) {
-            [self incrementSessionBannerCount];
-            [self incrementDailyBannerCount];
-        }
-        appBannerViewController.view.alpha = 0.0;
-        [topController presentViewController:appBannerViewController animated:NO completion:^{
-            [appBannerViewController finishSetup];
-            if (!appBannerViewController.isPreloading) {
-                [appBannerViewController.cardCollectionView reloadData];
-                [appBannerViewController setBackground];
-                [UIView animateWithDuration:0.3 animations:^{
-                    appBannerViewController.view.alpha = 1.0;
-                }];
-            }
-        }];
+        [self presentBlockingBanner:appBannerViewController banner:banner notificationId:notificationId force:force];
     }
 
     if (banner.dismissType == CPAppBannerDismissTypeTimeout) {
@@ -1667,6 +1654,83 @@ int appBannerPerDayValue = 0;
     if (shownCallback) {
         shownCallback(banner);
     }
+}
+
+#pragma mark - Non-blocking banner presentation (child VC of top view controller)
+- (void)presentNonBlockingBanner:(CPAppBannerViewController*)appBannerViewController banner:(CPAppBanner*)banner notificationId:(NSString*)notificationId force:(BOOL)force {
+    if (!force && [CPUtils isNullOrEmpty:notificationId]) {
+        [self incrementSessionBannerCount];
+        [self incrementDailyBannerCount];
+    }
+    
+    UIViewController *hostVC = [CleverPush topViewController];
+    if (!hostVC) {
+        return;
+    }
+
+    CPAppBannerPassthroughView *overlay = [[CPAppBannerPassthroughView alloc] initWithFrame:hostVC.view.bounds];
+    overlay.backgroundColor = [UIColor clearColor];
+    overlay.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+
+    [hostVC addChildViewController:appBannerViewController];
+    appBannerViewController.view.frame = overlay.bounds;
+    appBannerViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    appBannerViewController.view.alpha = 0.0;
+    [overlay addSubview:appBannerViewController.view];
+    [appBannerViewController didMoveToParentViewController:hostVC];
+
+    [hostVC.view addSubview:overlay];
+    activeBannerOverlay = overlay;
+
+    [appBannerViewController finishSetup];
+    if (!appBannerViewController.isPreloading) {
+        [appBannerViewController.cardCollectionView reloadData];
+        [appBannerViewController setBackground];
+    }
+
+    appBannerViewController.view.backgroundColor = [UIColor clearColor];
+
+    if ([banner.contentType isEqualToString:@"html"]) {
+        overlay.bannerContainerView = appBannerViewController.webView;
+    } else {
+        overlay.bannerContainerView = appBannerViewController.bannerContainer;
+        overlay.closeButtonView = appBannerViewController.btnClose;
+    }
+    [UIView animateWithDuration:0.3 animations:^{
+        appBannerViewController.view.alpha = 1.0;
+    }];
+
+    __weak CPAppBannerPassthroughView *weakOverlay = overlay;
+    appBannerViewController.windowDismissBlock = ^{
+        [appBannerViewController willMoveToParentViewController:nil];
+        [weakOverlay removeFromSuperview];
+        [appBannerViewController removeFromParentViewController];
+        activeBannerOverlay = nil;
+    };
+}
+
+#pragma mark - Blocking banner presentation (default modal)
+- (void)presentBlockingBanner:(CPAppBannerViewController*)appBannerViewController banner:(CPAppBanner*)banner notificationId:(NSString*)notificationId force:(BOOL)force {
+    [appBannerViewController setModalPresentationStyle:[CleverPush getAppBannerModalPresentationStyle]];
+    [appBannerViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
+
+    if (!force && [CPUtils isNullOrEmpty:notificationId]) {
+        [self incrementSessionBannerCount];
+        [self incrementDailyBannerCount];
+    }
+
+    UIViewController *topController = [CleverPush topViewController];
+    appBannerViewController.view.alpha = 0.0;
+    [topController presentViewController:appBannerViewController animated:NO completion:^{
+        [appBannerViewController finishSetup];
+        if (!appBannerViewController.isPreloading) {
+            [appBannerViewController.cardCollectionView reloadData];
+            [appBannerViewController setBackground];
+            [UIView animateWithDuration:0.3 animations:^{
+                appBannerViewController.view.alpha = 1.0;
+            }];
+        }
+    }];
 }
 
 #pragma mark - track the record of the banner callback events by calling an api (app-banner/event/@"event-name")
@@ -1799,6 +1863,10 @@ int appBannerPerDayValue = 0;
 
 - (void)setTrackingEnabled:(BOOL)enabled {
     trackingEnabled = enabled;
+}
+
+- (void)setAppBannersNonBlocking:(BOOL)nonBlocking {
+    appBannersNonBlocking = nonBlocking;
 }
 
 - (void)setCurrentEventId:(NSString*)eventId {

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -1701,10 +1701,11 @@ int appBannerPerDayValue = 0;
     }];
 
     __weak CPAppBannerPassthroughView *weakOverlay = overlay;
+    __weak CPAppBannerViewController *weakBannerVC = appBannerViewController;
     appBannerViewController.windowDismissBlock = ^{
-        [appBannerViewController willMoveToParentViewController:nil];
+        [weakBannerVC willMoveToParentViewController:nil];
         [weakOverlay removeFromSuperview];
-        [appBannerViewController removeFromParentViewController];
+        [weakBannerVC removeFromParentViewController];
         activeBannerOverlay = nil;
     };
 }

--- a/CleverPush/Source/CPAppBannerPassthroughView.h
+++ b/CleverPush/Source/CPAppBannerPassthroughView.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CPAppBannerPassthroughView : UIView
+@property (nonatomic, weak, nullable) UIView *bannerContainerView;
+@property (nonatomic, weak, nullable) UIView *closeButtonView;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CleverPush/Source/CPAppBannerPassthroughView.m
+++ b/CleverPush/Source/CPAppBannerPassthroughView.m
@@ -1,0 +1,38 @@
+#import "CPAppBannerPassthroughView.h"
+
+@implementation CPAppBannerPassthroughView
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    UIView *hitView = [super hitTest:point withEvent:event];
+
+    if (hitView == nil || hitView == self || self.bannerContainerView == nil) {
+        return nil;
+    }
+
+    if (self.closeButtonView && [hitView isDescendantOfView:self.closeButtonView]) {
+        return hitView;
+    }
+
+    if (![hitView isDescendantOfView:self.bannerContainerView]) {
+        return nil;
+    }
+
+    if (hitView == self.bannerContainerView) {
+        if ([hitView isMemberOfClass:[UIView class]]) {
+            return nil;
+        }
+        return hitView;
+    }
+
+    if ([hitView isKindOfClass:[UICollectionView class]]) {
+        return nil;
+    }
+
+    if ([hitView isMemberOfClass:[UIView class]]) {
+        return nil;
+    }
+
+    return hitView;
+}
+
+@end

--- a/CleverPush/Source/CPAppBannerViewController.h
+++ b/CleverPush/Source/CPAppBannerViewController.h
@@ -36,6 +36,7 @@
 @property (nonatomic, assign) long index;
 @property (nonatomic, strong) NSString *voucherCode;
 @property (nonatomic, assign) BOOL isPreloading;
+@property (nonatomic, copy) void (^windowDismissBlock)(void);
 @property (nonatomic, strong) IBOutlet WKWebView *webView;
 @property (weak, nonatomic) IBOutlet UIPageControl *pageControl;
 @property (weak, nonatomic) IBOutlet UICollectionView *cardCollectionView;

--- a/CleverPush/Source/CPAppBannerViewController.m
+++ b/CleverPush/Source/CPAppBannerViewController.m
@@ -889,7 +889,11 @@ static CPAppBannerActionBlock appBannerActionCallback;
         if (self.handleBannerClosed) {
             self.handleBannerClosed();
         }
-        [self dismissViewControllerAnimated:NO completion:nil];
+        if (self.windowDismissBlock) {
+            self.windowDismissBlock();
+        } else {
+            [self dismissViewControllerAnimated:NO completion:nil];
+        }
         [CPAppBannerModule showNextActivePendingBanner:self.data];
     });
 }

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -556,7 +556,6 @@
         }
     } else if (action.dismiss) {
         [self onDismiss];
-        [CPAppBannerModule showNextActivePendingBanner:self.data];
     } else {
         if (self.data.carouselEnabled || self.data.multipleScreensEnabled) {
             [self.changePage navigateToNextPage];

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -536,7 +536,15 @@
     self.actionCallback(action);
     if (action.openInWebview) {
         if (action.dismiss) {
-            [CPUtils openSafari:action.url dismissViewController:self.controller];
+            if (((CPAppBannerViewController *)self.controller).windowDismissBlock) {
+                NSURL *url = action.url;
+                [self onDismiss];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [CPUtils openSafari:url];
+                });
+            } else {
+                [CPUtils openSafari:action.url dismissViewController:self.controller];
+            }
         } else {
             [CPUtils openSafari:action.url];
         }
@@ -580,14 +588,18 @@
 }
 
 - (void)onDismiss {
-    dispatch_async(dispatch_get_main_queue(), ^(void) {
-        [[NSUserDefaults standardUserDefaults] setBool:false forKey:CLEVERPUSH_APP_BANNER_VISIBLE_KEY];
-        [[NSUserDefaults standardUserDefaults] synchronize];
-        if (self.handleBannerClosed) {
-            self.handleBannerClosed();
-        }
-        [self.controller dismissViewControllerAnimated:NO completion:nil];
-    });
+    if ([self.controller respondsToSelector:@selector(onDismiss)]) {
+        [self.controller onDismiss];
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^(void) {
+            [[NSUserDefaults standardUserDefaults] setBool:false forKey:CLEVERPUSH_APP_BANNER_VISIBLE_KEY];
+            [[NSUserDefaults standardUserDefaults] synchronize];
+            if (self.handleBannerClosed) {
+                self.handleBannerClosed();
+            }
+            [self.controller dismissViewControllerAnimated:NO completion:nil];
+        });
+    }
 }
 
 #pragma mark - setting up the popup shadow

--- a/CleverPush/Source/CleverPush.h
+++ b/CleverPush/Source/CleverPush.h
@@ -90,6 +90,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 + (void)disableAppBanners;
 + (void)enableAppBanners;
 + (void)setAppBannerTrackingEnabled:(BOOL)enabled;
++ (void)setAppBannersNonBlocking:(BOOL)nonBlocking;
 + (BOOL)popupVisible;
 + (void)unsubscribe;
 + (void)unsubscribe:(void(^ _Nullable)(BOOL))callback;

--- a/CleverPush/Source/CleverPush.m
+++ b/CleverPush/Source/CleverPush.m
@@ -228,6 +228,10 @@ static CleverPush* singleInstance = nil;
     [self.CPSharedInstance setAppBannerTrackingEnabled:enabled];
 }
 
++ (void)setAppBannersNonBlocking:(BOOL)nonBlocking {
+    [self.CPSharedInstance setAppBannersNonBlocking:nonBlocking];
+}
+
 + (BOOL)popupVisible {
     return [self.CPSharedInstance popupVisible];
 }

--- a/CleverPush/Source/CleverPushInstance.h
+++ b/CleverPush/Source/CleverPushInstance.h
@@ -123,6 +123,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 - (void)disableAppBanners;
 - (void)enableAppBanners;
 - (void)setAppBannerTrackingEnabled:(BOOL)enabled;
+- (void)setAppBannersNonBlocking:(BOOL)nonBlocking;
 - (BOOL)popupVisible;
 - (void)unsubscribe;
 - (void)unsubscribe:(void(^ _Nullable)(BOOL))callback;

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -4603,6 +4603,10 @@ static id isNil(id object) {
     [CPAppBannerModule setTrackingEnabled:enabled];
 }
 
+- (void)setAppBannersNonBlocking:(BOOL)nonBlocking {
+    [CPAppBannerModule setAppBannersNonBlocking:nonBlocking];
+}
+
 - (BOOL)getAppBannerDraftsEnabled {
     return isShowDraft;
 }


### PR DESCRIPTION
implemented functionality of allow users to interact with app while in-app banner is visible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows in-app banners to be non-blocking so users can keep using the app while a banner is visible. Default stays modal; opt in via a new API. Addresses CP-10601.

- **New Features**
  - Added `+[CleverPush setAppBannersNonBlocking:]` (also on `CleverPushInstance` and `CPAppBannerModule`) to switch to a pass-through overlay.
  - Non-blocking mode embeds `CPAppBannerViewController` as a child and uses `CPAppBannerPassthroughView` to forward touches outside the banner while keeping the close button active.
  - Unified dismissal via `windowDismissBlock`; when a banner action opens Safari and dismisses, we dismiss first, then open the link. Modal flow is unchanged.

<sup>Written for commit 05595c11e1aa1bed88006a1075e8d0496c6b1d8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

