### PR TITLE
feature/cp-11408-add-translation-feature-to-app-push-ios

### DIFF
--- a/CleverPush/Source/CPChannelTopic.h
+++ b/CleverPush/Source/CPChannelTopic.h
@@ -13,6 +13,8 @@
 @property (readonly, nullable) NSDictionary *customData;
 @property (readonly, nullable) NSDate *createdAt;
 @property (nonatomic, readwrite) BOOL defaultUnchecked;
+@property (readonly) BOOL nameTranslationEnabled;
+@property (readonly, nullable) NSDictionary *nameTranslation;
 
 #pragma mark - Class Methods
 + (instancetype _Nonnull)initWithJson:(nonnull NSDictionary*)json;

--- a/CleverPush/Source/CPChannelTopic.m
+++ b/CleverPush/Source/CPChannelTopic.m
@@ -31,6 +31,16 @@
         _defaultUnchecked = YES;
     }
 
+    _nameTranslationEnabled = NO;
+    if ([json objectForKey:@"nameTranslationEnabled"] != nil && ![[json objectForKey:@"nameTranslationEnabled"] isKindOfClass:[NSNull class]] && [[json objectForKey:@"nameTranslationEnabled"] boolValue]) {
+        _nameTranslationEnabled = YES;
+    }
+
+    id nameTranslationValue = [json objectForKey:@"nameTranslation"];
+    if (nameTranslationValue != nil && ![[json objectForKey:@"nameTranslation"] isKindOfClass:[NSNull class]] && [nameTranslationValue isKindOfClass:[NSDictionary class]]) {
+        _nameTranslation = (NSDictionary *)nameTranslationValue;
+    }
+
     if ([[json objectForKey:@"createdAt"] isKindOfClass:[NSString class]]) {
         _createdAt = [CPUtils getLocalDateTimeFromUTC:[json objectForKey:@"createdAt"]];
     }

--- a/CleverPush/Source/CPTopicsViewController.m
+++ b/CleverPush/Source/CPTopicsViewController.m
@@ -269,6 +269,26 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
     return selectedState;
 }
 
+#pragma mark - Resolve the localized display name for a topic based on device locale
+- (NSString *)resolveLocalizedDisplayName:(CPChannelTopic *)topic {
+    if (!topic.nameTranslationEnabled || topic.nameTranslation == nil || [topic.nameTranslation count] == 0) {
+        return topic.name ?: @"";
+    }
+    NSString *language = [[[NSLocale preferredLanguages] firstObject] substringToIndex:2];
+    NSString *translated = topic.nameTranslation[language];
+    if (translated != nil && [translated length] > 0) {
+        return translated;
+    }
+    NSString *region = [[[NSLocale currentLocale] objectForKey:NSLocaleCountryCode] lowercaseString];
+    if (region) {
+        translated = topic.nameTranslation[region];
+        if (translated != nil && [translated length] > 0) {
+            return translated;
+        }
+    }
+    return topic.name ?: @"";
+}
+
 #pragma mark - Delegate & DataSource List of the subscription.
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     int count = 0;
@@ -389,7 +409,7 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
     }
     [cell updateSeparatorWithTopicHighlighter];
     cell.titleText.attributedText = nil;
-    cell.titleText.text = [topic name];
+    cell.titleText.text = [self resolveLocalizedDisplayName:topic];
     cell.titleText.tag = 200;
     cell.titleText.backgroundColor = [UIColor clearColor];
     cell.accessibilityLabel = cell.titleText.text;

--- a/CleverPush/Source/CPTopicsViewController.m
+++ b/CleverPush/Source/CPTopicsViewController.m
@@ -272,14 +272,28 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
 #pragma mark - Resolve the localized display name for a topic based on device locale
 - (NSString *)resolveLocalizedDisplayName:(CPChannelTopic *)topic {
     if (!topic.nameTranslationEnabled || topic.nameTranslation == nil || [topic.nameTranslation count] == 0) {
-        return topic.name ?: @"";
+        if (topic.name) {
+            return topic.name;
+        }
+        return @"";
     }
-    NSString *language = [[[NSLocale preferredLanguages] firstObject] substringToIndex:2];
-    NSString *translated = topic.nameTranslation[language];
-    if (translated != nil && [translated length] > 0) {
-        return translated;
+    NSString *preferredLocale = [[NSLocale preferredLanguages] firstObject];
+    if (preferredLocale) {
+        NSString *language;
+        if (preferredLocale.length >= 2) {
+            language = [preferredLocale substringToIndex:2];
+        } else {
+            language = preferredLocale;
+        }
+        id translated = topic.nameTranslation[language];
+        if ([translated isKindOfClass:[NSString class]] && [translated length] > 0) {
+            return translated;
+        }
     }
-    return topic.name ?: @"";
+    if (topic.name) {
+        return topic.name;
+    }
+    return @"";
 }
 
 #pragma mark - Delegate & DataSource List of the subscription.

--- a/CleverPush/Source/CPTopicsViewController.m
+++ b/CleverPush/Source/CPTopicsViewController.m
@@ -279,12 +279,7 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
     }
     NSString *preferredLocale = [[NSLocale preferredLanguages] firstObject];
     if (preferredLocale) {
-        NSString *language;
-        if (preferredLocale.length >= 2) {
-            language = [preferredLocale substringToIndex:2];
-        } else {
-            language = preferredLocale;
-        }
+        NSString *language = [[preferredLocale componentsSeparatedByString:@"-"] firstObject];
         id translated = topic.nameTranslation[language];
         if ([translated isKindOfClass:[NSString class]] && [translated length] > 0) {
             return translated;

--- a/CleverPush/Source/CPTopicsViewController.m
+++ b/CleverPush/Source/CPTopicsViewController.m
@@ -279,13 +279,6 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
     if (translated != nil && [translated length] > 0) {
         return translated;
     }
-    NSString *region = [[[NSLocale currentLocale] objectForKey:NSLocaleCountryCode] lowercaseString];
-    if (region) {
-        translated = topic.nameTranslation[region];
-        if (translated != nil && [translated length] > 0) {
-            return translated;
-        }
-    }
     return topic.name ?: @"";
 }
 


### PR DESCRIPTION
Add topic name translation support with locale-based fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds optional parsing and display fallback logic for topic names, without changing subscription state handling or network behavior.
> 
> **Overview**
> Adds topic name translation support by parsing `nameTranslationEnabled` and `nameTranslation` onto `CPChannelTopic` from the topic JSON.
> 
> Updates the topics dialog to display a localized topic title via `resolveLocalizedDisplayName`, selecting a translation based on the device’s preferred language (with fallback to the original `name`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7704389b20579618d53ca375353af41ea2bbb98a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds localized topic names in the topics list with device-locale fallback. Satisfies CP-11408 by showing translated names when available without breaking existing topics.

- **New Features**
  - Parse `nameTranslationEnabled` and `nameTranslation` from topic JSON in `CPChannelTopic`.
  - Add `resolveLocalizedDisplayName` in `CPTopicsViewController` to pick translation by preferred language (2-letter) with fallback to `name`; topic cells now use this value.

<sup>Written for commit 7704389b20579618d53ca375353af41ea2bbb98a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

