### PR TITLE
feature/cp-11320-db-support-for-enhanced-topic-selection-popup-configurable

### DIFF
--- a/CleverPush/Source/CPTopicsViewController.h
+++ b/CleverPush/Source/CPTopicsViewController.h
@@ -17,6 +17,7 @@
 @property (nonatomic, assign) BOOL topicsDialogShowUnsubscribe;
 @property (nonatomic, weak) id<ManageHeight> delegate;
 @property (nonatomic, assign) BOOL topicsDialogShowWhenNewAdded;
+@property (nonatomic, assign) BOOL topicsDialogBulkActions;
 
 #pragma mark - Class Methods
 - (id)initWithAvailableTopics:(NSArray*)topics selectedTopics:(NSArray*)userTopics hasSubscriptionTopics:(BOOL)hasTopics;

--- a/CleverPush/Source/CPTopicsViewController.m
+++ b/CleverPush/Source/CPTopicsViewController.m
@@ -102,7 +102,7 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
         topic.defaultUnchecked = YES;
     }
     hasTopics = YES;
-    if (self.topicsDialogShowUnsubscribe) {
+    if (self.topicsDialogShowUnsubscribe && !self.topicsDialogBulkActions) {
         [CleverPush updateDeselectFlag:YES];
     }
     [self reloadTableView];

--- a/CleverPush/Source/CPTopicsViewController.m
+++ b/CleverPush/Source/CPTopicsViewController.m
@@ -78,9 +78,39 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
     hasTopics = NO;
 }
 
+#pragma mark - Select all topics (including sub-topics)
+- (void)selectAllTopics {
+    [selectedTopics removeAllObjects];
+    for (CPChannelTopic *topic in availableTopics) {
+        topic.defaultUnchecked = NO;
+        NSString *topicId = [topic id];
+        if (topicId && [topicId isKindOfClass:[NSString class]]) {
+            [selectedTopics addObject:topicId];
+        }
+    }
+    hasTopics = YES;
+    if (self.topicsDialogShowUnsubscribe) {
+        [CleverPush updateDeselectFlag:NO];
+    }
+    [self reloadTableView];
+}
+
+#pragma mark - Remove all topic selections (including sub-topics)
+- (void)removeAllTopics {
+    [selectedTopics removeAllObjects];
+    for (CPChannelTopic *topic in availableTopics) {
+        topic.defaultUnchecked = YES;
+    }
+    hasTopics = YES;
+    if (self.topicsDialogShowUnsubscribe) {
+        [CleverPush updateDeselectFlag:YES];
+    }
+    [self reloadTableView];
+}
+
 #pragma mark - Set the table header title
 - (void)tableHeaderTitle {
-    int labelPaddingBottom = 15;
+    int labelPaddingBottom = (self.topicsDialogBulkActions || self.topicsDialogShowUnsubscribe) ? 2 : 8;
     UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, tableView.frame.size.width, CPConstraints)];
     titleLabel.textAlignment = NSTextAlignmentCenter;
     titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
@@ -269,26 +299,27 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
     return selectedState;
 }
 
-#pragma mark - Resolve the localized display name for a topic based on device locale
-- (NSString *)resolveLocalizedDisplayName:(CPChannelTopic *)topic {
-    if (!topic.nameTranslationEnabled || topic.nameTranslation == nil || [topic.nameTranslation count] == 0) {
-        if (topic.name) {
-            return topic.name;
-        }
-        return @"";
+#pragma mark - Returns YES if every available topic is currently selected
+- (BOOL)areAllTopicsSelected {
+    if ([availableTopics count] == 0) {
+        return NO;
     }
-    NSString *preferredLocale = [[NSLocale preferredLanguages] firstObject];
-    if (preferredLocale) {
-        NSString *language = [[preferredLocale componentsSeparatedByString:@"-"] firstObject];
-        id translated = topic.nameTranslation[language];
-        if ([translated isKindOfClass:[NSString class]] && [translated length] > 0) {
-            return translated;
+    for (CPChannelTopic *topic in availableTopics) {
+        if (![self topicState:topic]) {
+            return NO;
         }
     }
-    if (topic.name) {
-        return topic.name;
+    return YES;
+}
+
+#pragma mark - Returns YES if at least one available topic is currently selected
+- (BOOL)areAnyTopicsSelected {
+    for (CPChannelTopic *topic in availableTopics) {
+        if ([self topicState:topic]) {
+            return YES;
+        }
     }
-    return @"";
+    return NO;
 }
 
 #pragma mark - Delegate & DataSource List of the subscription.
@@ -305,37 +336,84 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
-    UIView *headerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, tableView.bounds.size.width, CPTopicHeight)];
-    
+    BOOL showUnsubscribe = self.topicsDialogShowUnsubscribe;
+    BOOL showBulkActions = self.topicsDialogBulkActions;
+
+    if (!showUnsubscribe && !showBulkActions) {
+        return nil;
+    }
+
+    CGFloat totalHeight = 0;
+    if (showUnsubscribe) totalHeight += CPTopicHeight;
+    if (showBulkActions) totalHeight += CPTopicHeight;
+
+    UIView *headerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, tableView.bounds.size.width, totalHeight)];
+    headerView.backgroundColor = UIColor.clearColor;
+
     CGFloat switchTrailing = CPTopicSwitchTrailingDefault;
     if (@available(iOS 26.0, *)) {
         switchTrailing = CPTopicSwitchTrailingiOS26;
     }
-    
-    UISwitch* deselectSwitch = [[UISwitch alloc] init];
-    CGSize switchSize = [deselectSwitch sizeThatFits:CGSizeZero];
-    deselectSwitch.frame = CGRectMake(tableView.bounds.size.width - (switchSize.width + switchTrailing), (CPTopicHeight - switchSize.height) / CPTopicHeightDivider, switchSize.width, switchSize.height);
-    
-    if ([CleverPush getNormalTintColor]) {
-        deselectSwitch.onTintColor = [CleverPush getNormalTintColor];
-    } else {
-        deselectSwitch.onTintColor = [UIColor systemGreenColor];
+
+    CGFloat yOffset = 0;
+
+    if (showUnsubscribe) {
+        UISwitch *deselectSwitch = [[UISwitch alloc] init];
+        CGSize switchSize = [deselectSwitch sizeThatFits:CGSizeZero];
+        deselectSwitch.frame = CGRectMake(
+            tableView.bounds.size.width - (switchSize.width + switchTrailing),
+            yOffset + (CPTopicHeight - switchSize.height) / CPTopicHeightDivider,
+            switchSize.width,
+            switchSize.height
+        );
+        deselectSwitch.onTintColor = [CleverPush getNormalTintColor] ?: [UIColor systemGreenColor];
+        [deselectSwitch addTarget:self action:@selector(deselectEverything:) forControlEvents:UIControlEventValueChanged];
+        deselectSwitch.on = ([CleverPush getDeselectValue] == YES);
+        [headerView addSubview:deselectSwitch];
+
+        UILabel *deselectLabel = [[UILabel alloc] init];
+        deselectLabel.text = [CPTranslate translate:@"deselectEverything"];
+        deselectLabel.frame = CGRectMake(
+            CPTopicCellLeading,
+            yOffset + (CPTopicHeight - switchSize.height) / CPTopicHeightDivider,
+            tableView.bounds.size.width - (switchSize.width + switchTrailing + CPTopicCellLeading),
+            switchSize.height
+        );
+        [headerView addSubview:deselectLabel];
+
+        yOffset += CPTopicHeight;
     }
-    
-    [deselectSwitch addTarget:self action:@selector(deselectEverything:) forControlEvents:UIControlEventValueChanged];
-    [headerView addSubview:deselectSwitch];
-    
-    if ([CleverPush getDeselectValue] == YES) {
-        deselectSwitch.on = YES;
-    } else {
-        deselectSwitch.on = NO;
+
+    if (showBulkActions) {
+        UIColor *tintColor = [CleverPush getNormalTintColor] ?: [UIColor systemBlueColor];
+
+        UIButton *selectAllButton = [UIButton buttonWithType:UIButtonTypeSystem];
+        [selectAllButton setTitle:[CPTranslate translate:@"selectAll"] forState:UIControlStateNormal];
+        [selectAllButton setTitleColor:tintColor forState:UIControlStateNormal];
+        [selectAllButton setTitleColor:[UIColor systemGrayColor] forState:UIControlStateDisabled];
+        selectAllButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
+        selectAllButton.titleEdgeInsets = UIEdgeInsetsMake(0, CPTopicCellLeading, 0, 0);
+        selectAllButton.enabled = ![self areAllTopicsSelected];
+        [selectAllButton addTarget:self action:@selector(selectAllTopics) forControlEvents:UIControlEventTouchUpInside];
+
+        UIButton *removeAllButton = [UIButton buttonWithType:UIButtonTypeSystem];
+        [removeAllButton setTitle:[CPTranslate translate:@"removeAll"] forState:UIControlStateNormal];
+        [removeAllButton setTitleColor:tintColor forState:UIControlStateNormal];
+        [removeAllButton setTitleColor:[UIColor systemGrayColor] forState:UIControlStateDisabled];
+        removeAllButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
+        removeAllButton.titleEdgeInsets = UIEdgeInsetsMake(0, 0, 0, CPTopicCellLeading);
+        removeAllButton.enabled = [self areAnyTopicsSelected];
+        [removeAllButton addTarget:self action:@selector(removeAllTopics) forControlEvents:UIControlEventTouchUpInside];
+
+        UIStackView *bulkStack = [[UIStackView alloc] initWithArrangedSubviews:@[selectAllButton, removeAllButton]];
+        bulkStack.axis = UILayoutConstraintAxisHorizontal;
+        bulkStack.distribution = UIStackViewDistributionFillEqually;
+        bulkStack.alignment = UIStackViewAlignmentFill;
+        bulkStack.spacing = 0;
+        bulkStack.frame = CGRectMake(0, yOffset, tableView.bounds.size.width, CPTopicHeight);
+        [headerView addSubview:bulkStack];
     }
-    
-    UILabel* deselectEverything = [[UILabel alloc] init];
-    deselectEverything.text = [CPTranslate translate:@"deselectEverything"];
-    deselectEverything.frame = CGRectMake(CPTopicCellLeading, (CPTopicHeight - switchSize.height) / CPTopicHeightDivider, tableView.bounds.size.width - (switchSize.width + switchTrailing + CPTopicCellLeading), switchSize.height);
-    [headerView addSubview:deselectEverything];
-    
+
     return headerView;
 }
 
@@ -411,7 +489,7 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
     }
     [cell updateSeparatorWithTopicHighlighter];
     cell.titleText.attributedText = nil;
-    cell.titleText.text = [self resolveLocalizedDisplayName:topic];
+    cell.titleText.text = [topic name];
     cell.titleText.tag = 200;
     cell.titleText.backgroundColor = [UIColor clearColor];
     cell.accessibilityLabel = cell.titleText.text;
@@ -450,12 +528,24 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
     return UITableViewAutomaticDimension;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForHeaderInSection:(NSInteger)section {
-    if (self.topicsDialogShowUnsubscribe == NO) {
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
+    if (!self.topicsDialogShowUnsubscribe && !self.topicsDialogBulkActions) {
         return 0;
-    } else {
-        return CPTopicHeight;
     }
+    CGFloat height = 0;
+    if (self.topicsDialogShowUnsubscribe) height += CPTopicHeight;
+    if (self.topicsDialogBulkActions) height += CPTopicHeight;
+    return height;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForHeaderInSection:(NSInteger)section {
+    if (!self.topicsDialogShowUnsubscribe && !self.topicsDialogBulkActions) {
+        return 0;
+    }
+    CGFloat height = 0;
+    if (self.topicsDialogShowUnsubscribe) height += CPTopicHeight;
+    if (self.topicsDialogBulkActions) height += CPTopicHeight;
+    return height;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView estimatedHeightForFooterInSection:(NSInteger)section {

--- a/CleverPush/Source/CPTopicsViewController.m
+++ b/CleverPush/Source/CPTopicsViewController.m
@@ -102,7 +102,7 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
         topic.defaultUnchecked = YES;
     }
     hasTopics = YES;
-    if (self.topicsDialogShowUnsubscribe && !self.topicsDialogBulkActions) {
+    if (self.topicsDialogShowUnsubscribe) {
         [CleverPush updateDeselectFlag:YES];
     }
     [self reloadTableView];

--- a/CleverPush/Source/CPTopicsViewController.m
+++ b/CleverPush/Source/CPTopicsViewController.m
@@ -299,13 +299,25 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
     return selectedState;
 }
 
+#pragma mark - Resolve the display name for a topic, respecting device-locale translation when configured
+- (NSString *)resolveLocalizedDisplayName:(CPChannelTopic *)topic {
+    if (topic.nameTranslationEnabled && topic.nameTranslation) {
+        NSString *languageCode = [[NSLocale preferredLanguages].firstObject componentsSeparatedByString:@"-"].firstObject;
+        NSString *translated = topic.nameTranslation[languageCode];
+        if (translated && [translated isKindOfClass:[NSString class]] && translated.length > 0) {
+            return translated;
+        }
+    }
+    return [topic name] ?: @"";
+}
+
 #pragma mark - Returns YES if every available topic is currently selected
 - (BOOL)areAllTopicsSelected {
     if ([availableTopics count] == 0) {
         return NO;
     }
     for (CPChannelTopic *topic in availableTopics) {
-        if (![self topicState:topic]) {
+        if (![self defaultTopicState:topic]) {
             return NO;
         }
     }
@@ -315,7 +327,7 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
 #pragma mark - Returns YES if at least one available topic is currently selected
 - (BOOL)areAnyTopicsSelected {
     for (CPChannelTopic *topic in availableTopics) {
-        if ([self topicState:topic]) {
+        if ([self defaultTopicState:topic]) {
             return YES;
         }
     }
@@ -489,7 +501,7 @@ static CGFloat const CPTopicMinimumTitleWidth = 80.0;
     }
     [cell updateSeparatorWithTopicHighlighter];
     cell.titleText.attributedText = nil;
-    cell.titleText.text = [topic name];
+    cell.titleText.text = [self resolveLocalizedDisplayName:topic];
     cell.titleText.tag = 200;
     cell.titleText.backgroundColor = [UIColor clearColor];
     cell.accessibilityLabel = cell.titleText.text;

--- a/CleverPush/Source/CPTranslate.m
+++ b/CleverPush/Source/CPTranslate.m
@@ -14,13 +14,17 @@
                 @"deselectEverything": @"Deselect everything",
                 @"subscribedTopics": @"Subscribed Topics",
                 @"notificationsEmpty": @"No notifications available",
-                @"save": @"Save"
+                @"save": @"Save",
+                @"selectAll": @"Select All",
+                @"removeAll": @"Remove All"
         },
         @"de": @{
                 @"deselectEverything": @"Alles abwählen",
                 @"subscribedTopics": @"Abonnierte Themen",
                 @"notificationsEmpty": @"Keine Nachrichten verfügbar",
-                @"save": @"Speichern"
+                @"save": @"Speichern",
+                @"selectAll": @"Alle auswählen",
+                @"removeAll": @"Alle entfernen"
         },
     };
     

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -4271,11 +4271,20 @@ static id isNil(id object) {
         }
         [self getChannelConfig:^(NSDictionary* channelConfig) {
             NSString* headerTitle = [CPTranslate translate:@"subscribedTopics"];
+            NSString* saveButtonTitle = [CPTranslate translate:@"save"];
+            BOOL topicsDialogBulkActions = ([channelConfig objectForKey:@"topicsDialogBulkActions"] != nil) &&
+                                                      ![[channelConfig objectForKey:@"topicsDialogBulkActions"] isKindOfClass:[NSNull class]] &&
+                                                      [[channelConfig objectForKey:@"topicsDialogBulkActions"] boolValue];
+            
 
             if (channelConfig != nil && [channelConfig cleverPushStringForKey:@"confirmAlertSelectTopicsLaterTitle"] != nil && ![[channelConfig cleverPushStringForKey:@"confirmAlertSelectTopicsLaterTitle"] isEqualToString:@""]) {
                 headerTitle = [channelConfig cleverPushStringForKey:@"confirmAlertSelectTopicsLaterTitle"];
             }
 
+            if (channelConfig != nil && ![CPUtils isNullOrEmpty:[channelConfig cleverPushStringForKey:@"confirmAlertSelectTopicsSaveText"]]) {
+                saveButtonTitle = [channelConfig cleverPushStringForKey:@"confirmAlertSelectTopicsSaveText"];
+            }
+            
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (![self isSubscribed]) {
                     [self initTopicsDialogData:channelConfig syncToBackend:NO];
@@ -4296,7 +4305,9 @@ static id isNil(id object) {
                     topicsController.topicsDialogShowWhenNewAdded = [[channelConfig objectForKey:@"topicsDialogShowWhenNewAdded"] boolValue];
                 }
 
-                DWAlertAction*okAction = [DWAlertAction actionWithTitle:[CPTranslate translate:@"save"] style:DWAlertActionStyleCancel handler:^(DWAlertAction* action) {
+                topicsController.topicsDialogBulkActions = topicsDialogBulkActions;
+
+                DWAlertAction*okAction = [DWAlertAction actionWithTitle:saveButtonTitle style:DWAlertActionStyleCancel handler:^(DWAlertAction* action) {
                     if (topicsController.topicsDialogShowUnsubscribe
                         && [self getDeselectValue] == YES) {
                         [self unsubscribe];


### PR DESCRIPTION
implemented SelectAll & RemoveAll buttons functionality for topicsDialogue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new selection/unselection paths in the topics dialog (including unsubscribe flag interactions) driven by channel config, which could affect subscription state if the new bulk logic is incorrect. Changes are localized to the topics dialog UI and its config wiring, with minimal backend/data model impact.
> 
> **Overview**
> Adds an optional *bulk actions* row to the topics selection dialog header (gated by channel config `topicsDialogBulkActions`) with **“Select All”** and **“Remove All”** buttons that update topic selection state and refresh the dialog.
> 
> Updates the header to support stacking the existing unsubscribe switch and the new bulk actions row with dynamic heights, and adjusts topic name localization to only use translations when enabled (otherwise falling back to `topic.name`). Also adds `selectAll`/`removeAll` translations (EN/DE) and allows overriding the dialog’s save button label via `confirmAlertSelectTopicsSaveText`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48b1b88f2ff92918bff444fe0c57a1198398aae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional “Select All” and “Remove All” bulk actions to the topics dialog, controlled by channel config, with a stacked header and auto-enabled states. Syncs bulk actions with the unsubscribe switch, adds EN/DE labels, makes the save button text configurable, and improves topic name localization. Fulfills Linear CP-11320.

- **New Features**
  - Add `topicsDialogBulkActions` to show “Select All” / “Remove All”.
  - Buttons select/clear all topics (incl. sub-topics); auto-enable/disable based on selection. “Remove All” turns the unsubscribe switch ON when visible.
  - Header stacks unsubscribe and bulk actions with correct height.
  - Support custom save text via `confirmAlertSelectTopicsSaveText`; add `selectAll` / `removeAll` translations (EN/DE).
  - Topic names respect per-topic translations with a default-name fallback.

- **Migration**
  - To enable: set `topicsDialogBulkActions: true` in the channel config.
  - Optional: set `confirmAlertSelectTopicsSaveText` to override the save button label.

<sup>Written for commit a48b1b88f2ff92918bff444fe0c57a1198398aae. Summary will update on new commits. <a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/378?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

