### PR TITLE
hotfix/cp-11693-app-push-application-crash-during-backgroundforeground

### DIFF
--- a/CleverPush/Source/CPUtils.m
+++ b/CleverPush/Source/CPUtils.m
@@ -1234,11 +1234,7 @@ NSString * const localeIdentifier = @"en_US_POSIX";
 
     if (attributedString.length == 0) {
         NSAttributedString *fallback = [CPUtils plainAttributedStringFromHTML:safeHTML font:font textColor:textColor textAlignment:textAlignment];
-        if (fallback.length == 0) {
-            return nil;
-        }
-        [cache setObject:fallback forKey:cacheKey];
-        return fallback;
+        return fallback.length > 0 ? fallback : nil;
     }
     
     [attributedString enumerateAttribute:NSFontAttributeName

--- a/CleverPush/Source/CPUtils.m
+++ b/CleverPush/Source/CPUtils.m
@@ -1200,7 +1200,8 @@ NSString * const localeIdentifier = @"en_US_POSIX";
     }
 
     if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive) {
-        return [CPUtils plainAttributedStringFromHTML:safeHTML font:font textColor:textColor textAlignment:textAlignment];
+        NSAttributedString *fallback = [CPUtils plainAttributedStringFromHTML:safeHTML font:font textColor:textColor textAlignment:textAlignment];
+        return fallback.length > 0 ? fallback : nil;
     }
 
     NSString *htmlString = [NSString stringWithFormat:
@@ -1233,6 +1234,9 @@ NSString * const localeIdentifier = @"en_US_POSIX";
 
     if (attributedString.length == 0) {
         NSAttributedString *fallback = [CPUtils plainAttributedStringFromHTML:safeHTML font:font textColor:textColor textAlignment:textAlignment];
+        if (fallback.length == 0) {
+            return nil;
+        }
         [cache setObject:fallback forKey:cacheKey];
         return fallback;
     }

--- a/CleverPush/Source/CPUtils.m
+++ b/CleverPush/Source/CPUtils.m
@@ -1220,6 +1220,7 @@ NSString * const localeIdentifier = @"en_US_POSIX";
     };
     
     NSMutableAttributedString *attributedString = nil;
+    BOOL parserThrew = NO;
 
     @try {
         NSError *error = nil;
@@ -1230,11 +1231,18 @@ NSString * const localeIdentifier = @"en_US_POSIX";
     } @catch (NSException *exception) {
         [CPLog error:@"[CPUtils] Caught HTML parser exception: %@", exception.reason];
         attributedString = nil;
+        parserThrew = YES;
     }
 
     if (attributedString.length == 0) {
         NSAttributedString *fallback = [CPUtils plainAttributedStringFromHTML:safeHTML font:font textColor:textColor textAlignment:textAlignment];
-        return fallback.length > 0 ? fallback : nil;
+        if (fallback.length == 0) {
+            return nil;
+        }
+        if (!parserThrew) {
+            [cache setObject:fallback forKey:cacheKey];
+        }
+        return fallback;
     }
     
     [attributedString enumerateAttribute:NSFontAttributeName

--- a/CleverPush/Source/CPUtils.m
+++ b/CleverPush/Source/CPUtils.m
@@ -1139,10 +1139,52 @@ NSString * const localeIdentifier = @"en_US_POSIX";
 }
 
 #pragma mark - Convert HTML to NSAttributedString
++ (NSAttributedString *)plainAttributedStringFromHTML:(NSString *)html font:(UIFont *)font textColor:(UIColor *)textColor textAlignment:(NSTextAlignment)textAlignment {
+    NSString *plain = html ?: @"";
+
+    @try {
+        plain = [plain stringByReplacingOccurrencesOfString:@"(?i)<\\s*br\\s*/?>"
+                                                 withString:@"\n"
+                                                    options:NSRegularExpressionSearch
+                                                      range:NSMakeRange(0, plain.length)];
+        plain = [plain stringByReplacingOccurrencesOfString:@"<[^>]+>"
+                                                 withString:@""
+                                                    options:NSRegularExpressionSearch
+                                                      range:NSMakeRange(0, plain.length)];
+    } @catch (NSException *exception) {
+        plain = html ?: @"";
+    }
+
+    plain = [plain stringByReplacingOccurrencesOfString:@"&nbsp;" withString:@" "];
+    plain = [plain stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
+    plain = [plain stringByReplacingOccurrencesOfString:@"&lt;" withString:@"<"];
+    plain = [plain stringByReplacingOccurrencesOfString:@"&gt;" withString:@">"];
+    plain = [plain stringByReplacingOccurrencesOfString:@"&quot;" withString:@"\""];
+    plain = [plain stringByReplacingOccurrencesOfString:@"&#39;" withString:@"'"];
+
+    NSMutableAttributedString *fallback = [[NSMutableAttributedString alloc] initWithString:plain];
+    if (fallback.length > 0) {
+        NSRange fullRange = NSMakeRange(0, fallback.length);
+        if (font) {
+            [fallback addAttribute:NSFontAttributeName value:font range:fullRange];
+        }
+        if (textColor) {
+            [fallback addAttribute:NSForegroundColorAttributeName value:textColor range:fullRange];
+        }
+        NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+        paragraphStyle.alignment = textAlignment;
+        paragraphStyle.paragraphSpacing = 0;
+        paragraphStyle.paragraphSpacingBefore = 0;
+        [fallback addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:fullRange];
+    }
+    return fallback;
+}
+
 + (NSAttributedString *)attributedStringFromHTML:(NSString *)html font:(UIFont *)font textColor:(UIColor *)textColor textAlignment:(NSTextAlignment)textAlignment {
+    NSString *safeHTML = html ?: @"";
     NSString *colorHex = [CPUtils hexStringFromColor:textColor];
     NSString *cacheKey = [NSString stringWithFormat:@"%@|%@|%@|%.0f|%ld",
-                          html, colorHex, font.fontName, font.pointSize, (long)textAlignment];
+                          safeHTML, colorHex, font.fontName, font.pointSize, (long)textAlignment];
     NSCache *cache = [CPUtils sharedAttributedStringCache];
     NSAttributedString *cached = [cache objectForKey:cacheKey];
     if (cached != nil) {
@@ -1152,9 +1194,13 @@ NSString * const localeIdentifier = @"en_US_POSIX";
     if (![NSThread isMainThread]) {
         __block NSAttributedString *result = nil;
         dispatch_sync(dispatch_get_main_queue(), ^{
-            result = [CPUtils attributedStringFromHTML:html font:font textColor:textColor textAlignment:textAlignment];
+            result = [CPUtils attributedStringFromHTML:safeHTML font:font textColor:textColor textAlignment:textAlignment];
         });
         return result;
+    }
+
+    if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive) {
+        return [CPUtils plainAttributedStringFromHTML:safeHTML font:font textColor:textColor textAlignment:textAlignment];
     }
 
     NSString *htmlString = [NSString stringWithFormat:
@@ -1164,7 +1210,7 @@ NSString * const localeIdentifier = @"en_US_POSIX";
          "p,div,section,article,header,footer,blockquote,pre,h1,h2,h3,h4,h5,h6,ul,ol,li{margin:0;padding:0;}"
          "ul,ol{padding-left:1.2em;}"
          "</style>%@",
-        font.pointSize, colorHex, html];
+        font.pointSize, colorHex, safeHTML];
     
     NSData *data = [htmlString dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *options = @{
@@ -1172,11 +1218,23 @@ NSString * const localeIdentifier = @"en_US_POSIX";
         NSCharacterEncodingDocumentAttribute: @(NSUTF8StringEncoding)
     };
     
-    NSError *error = nil;
-    NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithData:data options:options documentAttributes:nil error:&error];
-    
-    if (error || attributedString.length == 0) {
-        return nil;
+    NSMutableAttributedString *attributedString = nil;
+
+    @try {
+        NSError *error = nil;
+        attributedString = [[NSMutableAttributedString alloc] initWithData:data options:options documentAttributes:nil error:&error];
+        if (error) {
+            attributedString = nil;
+        }
+    } @catch (NSException *exception) {
+        [CPLog error:@"[CPUtils] Caught HTML parser exception: %@", exception.reason];
+        attributedString = nil;
+    }
+
+    if (attributedString.length == 0) {
+        NSAttributedString *fallback = [CPUtils plainAttributedStringFromHTML:safeHTML font:font textColor:textColor textAlignment:textAlignment];
+        [cache setObject:fallback forKey:cacheKey];
+        return fallback;
     }
     
     [attributedString enumerateAttribute:NSFontAttributeName


### PR DESCRIPTION
Optimized attributedStringFromHTML function for preventing crash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized utility change with defensive fallbacks; may show simplified text instead of rich HTML when inactive or on parse failure, with no auth or data-path changes.
> 
> **Overview**
> **Hardens HTML-to-attributed-text conversion** in `CPUtils` so push/inbox/banner UI can render HTML without crashing during background/foreground transitions (CP-11693).
> 
> Adds **`plainAttributedStringFromHTML`**: strips tags (including `<br>` → newlines), decodes common entities, and applies the requested font, color, and alignment—used when full parsing is unsafe or fails.
> 
> **`attributedStringFromHTML`** now normalizes nil HTML, **skips `NSHTMLTextDocumentType` parsing when the app is not active** (plain fallback only), wraps parsing in **`@try/@catch`** with logging, and returns the plain fallback on errors or empty results instead of `nil`. Parser exceptions are **not cached**; other successful fallbacks can still be cached.
> 
> Call sites (`CPBannerCardContainer`, `CPInboxDetailContainer`) are unchanged; they get more reliable non-nil attributed strings in edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d481b0835577e4fd2db263cb60969e96397ab725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when converting HTML to NSAttributedString during background/foreground transitions by adding a safe plain-text fallback, stricter parsing guards, and smarter caching. Addresses Linear CP-11693.

- **Bug Fixes**
  - Added plainAttributedStringFromHTML that strips tags, handles <br>, decodes entities, applies font/color/alignment, and zeroes paragraph spacing.
  - Skip full HTML parsing when the app is not active; use the plain fallback instead.
  - Wrapped HTML parsing in try/catch; on error or empty result, return the fallback, cache it unless the parser threw, and log exceptions.
  - Normalized input with safeHTML for cache keys/parsing and kept main-thread parsing via dispatch_sync when needed.

<sup>Written for commit d481b0835577e4fd2db263cb60969e96397ab725. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

