### PR TITLE
feature/cp-11684-flutter-sdk-extend-test-subscription-status-management-ios

### DIFF
--- a/CleverPush/Source/CleverPush.h
+++ b/CleverPush/Source/CleverPush.h
@@ -97,6 +97,8 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 + (void)syncSubscription;
 + (void)markSubscriptionAsTest;
 + (void)markSubscriptionAsTestOnSuccess:(CPResultSuccessBlock _Nullable)successBlock onFailure:(CPFailureBlock _Nullable)failureBlock;
++ (void)unmarkSubscriptionAsTest;
++ (void)unmarkSubscriptionAsTestOnSuccess:(CPResultSuccessBlock _Nullable)successBlock onFailure:(CPFailureBlock _Nullable)failureBlock;
 + (void)didRegisterForRemoteNotifications:(UIApplication* _Nullable)app deviceToken:(NSData* _Nullable)inDeviceToken;
 + (void)handleDidFailRegisterForRemoteNotification:(NSError* _Nullable)err;
 + (void)handleNotificationOpened:(NSDictionary* _Nullable)messageDict isActive:(BOOL)isActive actionIdentifier:(NSString* _Nullable)actionIdentifier;

--- a/CleverPush/Source/CleverPush.m
+++ b/CleverPush/Source/CleverPush.m
@@ -256,6 +256,14 @@ static CleverPush* singleInstance = nil;
     [self.CPSharedInstance markSubscriptionAsTestOnSuccess:successBlock onFailure:failureBlock];
 }
 
++ (void)unmarkSubscriptionAsTest {
+    [self.CPSharedInstance unmarkSubscriptionAsTest];
+}
+
++ (void)unmarkSubscriptionAsTestOnSuccess:(CPResultSuccessBlock _Nullable)successBlock onFailure:(CPFailureBlock _Nullable)failureBlock {
+    [self.CPSharedInstance unmarkSubscriptionAsTestOnSuccess:successBlock onFailure:failureBlock];
+}
+
 + (void)didRegisterForRemoteNotifications:(UIApplication* _Nullable)app deviceToken:(NSData* _Nullable)inDeviceToken {
     [self.CPSharedInstance didRegisterForRemoteNotifications:app deviceToken:inDeviceToken];
 }

--- a/CleverPush/Source/CleverPushInstance.h
+++ b/CleverPush/Source/CleverPushInstance.h
@@ -132,6 +132,8 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 - (void)syncSubscription:(CPFailureBlock _Nullable)failureBlock successBlock:(void(^)())successBlock;
 - (void)markSubscriptionAsTest;
 - (void)markSubscriptionAsTestOnSuccess:(CPResultSuccessBlock _Nullable)successBlock onFailure:(CPFailureBlock _Nullable)failureBlock;
+- (void)unmarkSubscriptionAsTest;
+- (void)unmarkSubscriptionAsTestOnSuccess:(CPResultSuccessBlock _Nullable)successBlock onFailure:(CPFailureBlock _Nullable)failureBlock;
 - (void)didRegisterForRemoteNotifications:(UIApplication* _Nullable)app deviceToken:(NSData* _Nullable)inDeviceToken;
 - (void)handleDidFailRegisterForRemoteNotification:(NSError* _Nullable)err;
 - (void)handleNotificationOpened:(NSDictionary* _Nullable)messageDict isActive:(BOOL)isActive actionIdentifier:(NSString* _Nullable)actionIdentifier;

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1548,11 +1548,23 @@ static id isNil(id object) {
 }
 
 - (void)markSubscriptionAsTestOnSuccess:(CPResultSuccessBlock _Nullable)successBlock onFailure:(CPFailureBlock _Nullable)failureBlock {
+    [self setSubscriptionTestStatus:YES onSuccess:successBlock onFailure:failureBlock];
+}
+
+- (void)unmarkSubscriptionAsTest {
+    [self unmarkSubscriptionAsTestOnSuccess:nil onFailure:nil];
+}
+
+- (void)unmarkSubscriptionAsTestOnSuccess:(CPResultSuccessBlock _Nullable)successBlock onFailure:(CPFailureBlock _Nullable)failureBlock {
+    [self setSubscriptionTestStatus:NO onSuccess:successBlock onFailure:failureBlock];
+}
+
+- (void)setSubscriptionTestStatus:(BOOL)isTest onSuccess:(CPResultSuccessBlock _Nullable)successBlock onFailure:(CPFailureBlock _Nullable)failureBlock {
     if (channelId == nil) {
         channelId = [self getChannelIdFromUserDefaults];
     }
     if (channelId == nil || [channelId length] == 0) {
-        [CPLog warn:@"markSubscriptionAsTest: Channel ID is null"];
+        [CPLog warn:@"setSubscriptionTestStatus: Channel ID is null"];
         if (failureBlock) {
             failureBlock([NSError errorWithDomain:@"com.cleverpush" code:400 userInfo:@{NSLocalizedDescriptionKey:@"Channel ID is null or empty"}]);
         }
@@ -1560,7 +1572,7 @@ static id isNil(id object) {
     }
     [self getSubscriptionId:^(NSString*subscriptionId) {
         if (subscriptionId == nil || [subscriptionId length] == 0) {
-            [CPLog warn:@"markSubscriptionAsTest: There is no subscriptionId"];
+            [CPLog warn:@"setSubscriptionTestStatus: There is no subscriptionId"];
             if (failureBlock) {
                 failureBlock([NSError errorWithDomain:@"com.cleverpush" code:400 userInfo:@{NSLocalizedDescriptionKey:@"Subscription ID is null or empty"}]);
             }
@@ -1571,17 +1583,18 @@ static id isNil(id object) {
             NSDictionary* dataDic = [NSDictionary dictionaryWithObjectsAndKeys:
                                      channelId, @"channelId",
                                      subscriptionId, @"subscriptionId",
+                                     @(isTest), @"isTest",
                                      nil];
 
             NSData* postData = [NSJSONSerialization dataWithJSONObject:dataDic options:0 error:nil];
             [request setHTTPBody:postData];
             [self enqueueRequest:request onSuccess:^(NSDictionary* results) {
-                [CPLog debug:@"markSubscriptionAsTest: Successfully marked subscription as test"];
+                [CPLog debug:@"setSubscriptionTestStatus: Successfully set subscription tester status to %@", isTest ? @"true" : @"false"];
                 if (successBlock) {
                     successBlock(results);
                 }
             } onFailure:^(NSError* error) {
-                [CPLog error:@"markSubscriptionAsTest: Failed to mark subscription as test. %@", error];
+                [CPLog error:@"setSubscriptionTestStatus: Failed to set subscription tester status. %@", error];
                 if (failureBlock) {
                     failureBlock(error);
                 }

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1564,7 +1564,7 @@ static id isNil(id object) {
         channelId = [self getChannelIdFromUserDefaults];
     }
     if (channelId == nil || [channelId length] == 0) {
-        [CPLog warn:@"setSubscriptionTestStatus: Channel ID is null"];
+        [CPLog debug:@"setSubscriptionTestStatus: Channel ID is null"];
         if (failureBlock) {
             failureBlock([NSError errorWithDomain:@"com.cleverpush" code:400 userInfo:@{NSLocalizedDescriptionKey:@"Channel ID is null or empty"}]);
         }
@@ -1572,7 +1572,7 @@ static id isNil(id object) {
     }
     [self getSubscriptionId:^(NSString*subscriptionId) {
         if (subscriptionId == nil || [subscriptionId length] == 0) {
-            [CPLog warn:@"setSubscriptionTestStatus: There is no subscriptionId"];
+            [CPLog debug:@"setSubscriptionTestStatus: There is no subscriptionId"];
             if (failureBlock) {
                 failureBlock([NSError errorWithDomain:@"com.cleverpush" code:400 userInfo:@{NSLocalizedDescriptionKey:@"Subscription ID is null or empty"}]);
             }


### PR DESCRIPTION
Added `unmarkSubscriptionAsTest` method to unmark the subscription as a test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c62b666d953fb3939dd2e9e58be9f64a4f144633. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the ability to unmark a subscription as test on iOS and centralizes test status handling. Addresses Linear CP-11684 by extending test subscription status management for the Flutter SDK’s iOS layer.

- **New Features**
  - Added `unmarkSubscriptionAsTest` and `unmarkSubscriptionAsTestOnSuccess:onFailure:` in `CleverPush` and `CleverPushInstance`.
  - API payload now includes `isTest` to toggle tester status.

- **Refactors**
  - Introduced `setSubscriptionTestStatus:` and updated `markSubscriptionAsTestOnSuccess:onFailure:` to use it.
  - Improved logging (now debug) and input validation with proper error callbacks when Channel/Subscription IDs are missing.

<sup>Written for commit c62b666d953fb3939dd2e9e58be9f64a4f144633. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

