### PR TITLE
feature/cp-11714-add-exist-and-does-not-exist-logic-to-attributes-ios

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -730,14 +730,14 @@ int appBannerPerDayValue = 0;
             if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeExists)]) {
                 NSDictionary *subscriptionAttributes = [CleverPush getSubscriptionAttributes];
                 BOOL keyExists = NO;
-                if (subscriptionAttributes != nil) {
+                if (subscriptionAttributes != nil && attributeId != nil) {
                     keyExists = [subscriptionAttributes objectForKey:attributeId] != nil;
                 }
                 currentMatch = keyExists;
             } else if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeNotExists)]) {
                 NSDictionary *subscriptionAttributes = [CleverPush getSubscriptionAttributes];
                 BOOL keyExists = NO;
-                if (subscriptionAttributes != nil) {
+                if (subscriptionAttributes != nil && attributeId != nil) {
                     keyExists = [subscriptionAttributes objectForKey:attributeId] != nil;
                 }
                 currentMatch = !keyExists;

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -727,7 +727,15 @@ int appBannerPerDayValue = 0;
                 relation = @"equals";
             }
             
-            if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeContainsSubstring)]) {
+            if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeExists)]) {
+                BOOL hasValue = ([attributeValueObj isKindOfClass:[NSString class]] && [(NSString *)attributeValueObj length] > 0)
+                             || ([attributeValueObj isKindOfClass:[NSArray class]] && [(NSArray *)attributeValueObj count] > 0);
+                currentMatch = hasValue;
+            } else if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeNotExists)]) {
+                BOOL hasValue = ([attributeValueObj isKindOfClass:[NSString class]] && [(NSString *)attributeValueObj length] > 0)
+                             || ([attributeValueObj isKindOfClass:[NSArray class]] && [(NSArray *)attributeValueObj count] > 0);
+                currentMatch = !hasValue;
+            } else if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeContainsSubstring)]) {
                 if ([attributeValueObj isKindOfClass:[NSString class]]) {
                     NSString *attributeValue = (NSString *)attributeValueObj;
                     currentMatch = [attributeValue containsString:compareAttributeValue];

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -728,13 +728,19 @@ int appBannerPerDayValue = 0;
             }
             
             if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeExists)]) {
-                BOOL hasValue = ([attributeValueObj isKindOfClass:[NSString class]] && [(NSString *)attributeValueObj length] > 0)
-                             || ([attributeValueObj isKindOfClass:[NSArray class]] && [(NSArray *)attributeValueObj count] > 0);
-                currentMatch = hasValue;
+                NSDictionary *subscriptionAttributes = [CleverPush getSubscriptionAttributes];
+                BOOL keyExists = NO;
+                if (subscriptionAttributes != nil) {
+                    keyExists = [subscriptionAttributes objectForKey:attributeId] != nil;
+                }
+                currentMatch = keyExists;
             } else if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeNotExists)]) {
-                BOOL hasValue = ([attributeValueObj isKindOfClass:[NSString class]] && [(NSString *)attributeValueObj length] > 0)
-                             || ([attributeValueObj isKindOfClass:[NSArray class]] && [(NSArray *)attributeValueObj count] > 0);
-                currentMatch = !hasValue;
+                NSDictionary *subscriptionAttributes = [CleverPush getSubscriptionAttributes];
+                BOOL keyExists = NO;
+                if (subscriptionAttributes != nil) {
+                    keyExists = [subscriptionAttributes objectForKey:attributeId] != nil;
+                }
+                currentMatch = !keyExists;
             } else if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeContainsSubstring)]) {
                 if ([attributeValueObj isKindOfClass:[NSString class]]) {
                     NSString *attributeValue = (NSString *)attributeValueObj;

--- a/CleverPush/Source/CPFilterRelationType.h
+++ b/CleverPush/Source/CPFilterRelationType.h
@@ -6,7 +6,9 @@ typedef NS_ENUM(NSInteger, CPFilterRelationType) {
     CPFilterRelationTypeNotEqual,
     CPFilterRelationTypeContains,
     CPFilterRelationTypeNotContains,
-    CPFilterRelationTypeContainsSubstring
+    CPFilterRelationTypeContainsSubstring,
+    CPFilterRelationTypeExists,
+    CPFilterRelationTypeNotExists
 };
 
-#define filterRelationType(enum) [@[@"equals",@"lessThan",@"greaterThan",@"between",@"notEquals",@"contains",@"notContains",@"containsSubstring"] objectAtIndex:enum]
+#define filterRelationType(enum) [@[@"equals",@"lessThan",@"greaterThan",@"between",@"notEquals",@"contains",@"notContains",@"containsSubstring",@"exists",@"notExists"] objectAtIndex:enum]


### PR DESCRIPTION
Added a new Attribute condition type in Targeting for AppBanner: Exists/NotExists

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to banner targeting logic with no auth or data-model changes; behavior depends on subscription attribute dictionary contents.
> 
> **Overview**
> Adds **Exists** and **NotExists** attribute relations for App Banner targeting so campaigns can match on whether a subscription attribute **key** is present, without comparing values.
> 
> `CPFilterRelationType` gains `CPFilterRelationTypeExists` / `CPFilterRelationTypeNotExists`, wired to `"exists"` and `"notExists"` via `filterRelationType`. In `bannerTargetingAllowed:`, those relations are evaluated before value-based checks by looking up `attributeId` in `[CleverPush getSubscriptionAttributes]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b87d0c9c0606f0744499ec725d8e7798cafd7d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Exists/NotExists attribute conditions for AppBanner targeting so campaigns can match on the presence of a subscription attribute key. Implements Linear CP-11714.

- **New Features**
  - Added `CPFilterRelationTypeExists` and `CPFilterRelationTypeNotExists`; mapped to `"exists"`/`"notExists"` in `filterRelationType`.
  - Updated `bannerTargetingAllowed:` in `CPAppBannerModuleInstance` to check `[CleverPush getSubscriptionAttributes]` for the `attributeId`.

<sup>Written for commit 5b87d0c9c0606f0744499ec725d8e7798cafd7d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

