### PR TITLE
hotfix/cp-11872-ios-html-links-in-banner-do-not-open

### DIFF
--- a/CleverPush/Source/CPAppBannerModule.h
+++ b/CleverPush/Source/CPAppBannerModule.h
@@ -41,6 +41,7 @@
 + (void)enableBanners;
 + (void)setTrackingEnabled:(BOOL)enabled;
 + (void)setAppBannersNonBlocking:(BOOL)nonBlocking;
++ (BOOL)getAppBannersNonBlocking;
 + (void)resetInitialization;
 + (void)setCurrentEventId:(NSString*)eventId;
 + (void)sendBannerEvent:(NSString*)event forBanner:(CPAppBanner*)banner forScreen:(CPAppBannerCarouselBlock*)screen forButtonBlock:(CPAppBannerButtonBlock*)button forImageBlock:(CPAppBannerImageBlock*)image blockType:(NSString*)type;

--- a/CleverPush/Source/CPAppBannerModule.m
+++ b/CleverPush/Source/CPAppBannerModule.m
@@ -174,6 +174,10 @@ static CPAppBannerModuleInstance* singletonInstance = nil;
     [self.moduleInstance setAppBannersNonBlocking:nonBlocking];
 }
 
++ (BOOL)getAppBannersNonBlocking {
+    return [self.moduleInstance getAppBannersNonBlocking];
+}
+
 + (void)setCurrentEventId:(NSString*)eventId {
     [self.moduleInstance setCurrentEventId:eventId];
 }

--- a/CleverPush/Source/CPAppBannerModuleInstance.h
+++ b/CleverPush/Source/CPAppBannerModuleInstance.h
@@ -66,6 +66,7 @@
 - (void)enableBanners;
 - (void)setTrackingEnabled:(BOOL)enabled;
 - (void)setAppBannersNonBlocking:(BOOL)nonBlocking;
+- (BOOL)getAppBannersNonBlocking;
 - (void)setCurrentEventId:(NSString*)eventId;
 
 #pragma mark - refactor for testcases

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -1696,6 +1696,15 @@ int appBannerPerDayValue = 0;
     [hostVC.view addSubview:overlay];
     activeBannerOverlay = overlay;
 
+    __weak CPAppBannerPassthroughView *weakOverlay = overlay;
+    __weak CPAppBannerViewController *weakBannerVC = appBannerViewController;
+
+    if ([banner.contentType isEqualToString:@"html"]) {
+        appBannerViewController.htmlTouchableRectsDidChangeBlock = ^(NSArray<NSValue *> *rects) {
+            weakOverlay.webViewTouchableRects = rects;
+        };
+    }
+
     [appBannerViewController finishSetup];
     if (!appBannerViewController.isPreloading) {
         [appBannerViewController.cardCollectionView reloadData];
@@ -1706,6 +1715,9 @@ int appBannerPerDayValue = 0;
 
     if ([banner.contentType isEqualToString:@"html"]) {
         overlay.bannerContainerView = appBannerViewController.webView;
+        overlay.closeButtonView = appBannerViewController.htmlCloseButton;
+        overlay.htmlTouchPassthroughEnabled = YES;
+        overlay.webViewTouchableRects = @[[NSValue valueWithCGRect:appBannerViewController.webView.bounds]];
     } else {
         overlay.bannerContainerView = appBannerViewController.bannerContainer;
         overlay.closeButtonView = appBannerViewController.btnClose;
@@ -1714,8 +1726,6 @@ int appBannerPerDayValue = 0;
         appBannerViewController.view.alpha = 1.0;
     }];
 
-    __weak CPAppBannerPassthroughView *weakOverlay = overlay;
-    __weak CPAppBannerViewController *weakBannerVC = appBannerViewController;
     appBannerViewController.windowDismissBlock = ^{
         [weakBannerVC willMoveToParentViewController:nil];
         [weakOverlay removeFromSuperview];
@@ -1882,6 +1892,10 @@ int appBannerPerDayValue = 0;
 
 - (void)setAppBannersNonBlocking:(BOOL)nonBlocking {
     appBannersNonBlocking = nonBlocking;
+}
+
+- (BOOL)getAppBannersNonBlocking {
+    return appBannersNonBlocking;
 }
 
 - (void)setCurrentEventId:(NSString*)eventId {

--- a/CleverPush/Source/CPAppBannerPassthroughView.h
+++ b/CleverPush/Source/CPAppBannerPassthroughView.h
@@ -5,6 +5,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CPAppBannerPassthroughView : UIView
 @property (nonatomic, weak, nullable) UIView *bannerContainerView;
 @property (nonatomic, weak, nullable) UIView *closeButtonView;
+@property (nonatomic, assign) BOOL htmlTouchPassthroughEnabled;
+@property (nonatomic, copy, nullable) NSArray<NSValue *> *webViewTouchableRects;
 
 @end
 

--- a/CleverPush/Source/CPAppBannerPassthroughView.m
+++ b/CleverPush/Source/CPAppBannerPassthroughView.m
@@ -1,4 +1,5 @@
 #import "CPAppBannerPassthroughView.h"
+#import <WebKit/WebKit.h>
 
 @implementation CPAppBannerPassthroughView
 
@@ -13,8 +14,35 @@
         return hitView;
     }
 
+    if (self.htmlTouchPassthroughEnabled && [self.bannerContainerView isKindOfClass:[WKWebView class]]) {
+        if (![hitView isDescendantOfView:self.bannerContainerView] && hitView != self.bannerContainerView) {
+            return nil;
+        }
+
+        if (self.webViewTouchableRects == nil || self.webViewTouchableRects.count == 0) {
+            return hitView;
+        }
+
+        CGPoint webViewPoint = [self convertPoint:point toView:self.bannerContainerView];
+        for (NSValue *rectValue in self.webViewTouchableRects) {
+            if (CGRectContainsPoint([rectValue CGRectValue], webViewPoint)) {
+                return hitView;
+            }
+        }
+
+        return nil;
+    }
+
     if (![hitView isDescendantOfView:self.bannerContainerView]) {
         return nil;
+    }
+
+    WKWebView *webViewAtPoint = [self cp_webViewContainingPoint:point inAncestor:self.bannerContainerView];
+    if (webViewAtPoint != nil) {
+        if (hitView == webViewAtPoint || [hitView isDescendantOfView:webViewAtPoint]) {
+            return hitView;
+        }
+        return webViewAtPoint;
     }
 
     if (hitView == self.bannerContainerView) {
@@ -33,6 +61,31 @@
     }
 
     return hitView;
+}
+
+#pragma mark - WKWebView lookup
+- (nullable WKWebView *)cp_webViewContainingPoint:(CGPoint)point inAncestor:(UIView *)ancestor {
+    if (ancestor == nil || ancestor.hidden || ancestor.alpha < 0.01 || !ancestor.userInteractionEnabled) {
+        return nil;
+    }
+
+    CGPoint localPoint = [self convertPoint:point toView:ancestor];
+    if (![ancestor pointInside:localPoint withEvent:nil]) {
+        return nil;
+    }
+
+    for (UIView *subview in [ancestor.subviews reverseObjectEnumerator]) {
+        WKWebView *match = [self cp_webViewContainingPoint:point inAncestor:subview];
+        if (match != nil) {
+            return match;
+        }
+    }
+
+    if ([ancestor isKindOfClass:[WKWebView class]]) {
+        return (WKWebView *)ancestor;
+    }
+
+    return nil;
 }
 
 @end

--- a/CleverPush/Source/CPAppBannerViewController.h
+++ b/CleverPush/Source/CPAppBannerViewController.h
@@ -37,6 +37,7 @@
 @property (nonatomic, strong) NSString *voucherCode;
 @property (nonatomic, assign) BOOL isPreloading;
 @property (nonatomic, copy) void (^windowDismissBlock)(void);
+@property (nonatomic, copy, nullable) void (^htmlTouchableRectsDidChangeBlock)(NSArray<NSValue *> *rects);
 @property (nonatomic, strong) IBOutlet WKWebView *webView;
 @property (weak, nonatomic) IBOutlet UIPageControl *pageControl;
 @property (weak, nonatomic) IBOutlet UICollectionView *cardCollectionView;

--- a/CleverPush/Source/CPAppBannerViewController.m
+++ b/CleverPush/Source/CPAppBannerViewController.m
@@ -360,6 +360,9 @@ static CPAppBannerActionBlock appBannerActionCallback;
         } completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
             [self.view setNeedsLayout];
             [self.view layoutIfNeeded];
+            if ([CleverPush getAppBannersNonBlocking]) {
+                [self updateHTMLBannerTouchableRects];
+            }
         }];
     } else {
         CGFloat currentWidth = [UIScreen mainScreen].bounds.size.width;
@@ -821,7 +824,138 @@ static CPAppBannerActionBlock appBannerActionCallback;
     });
 }
 
+#pragma mark - HTML banner non-blocking touchable rect detection
+- (void)updateHTMLBannerTouchableRects {
+    if (![CleverPush getAppBannersNonBlocking]
+        || ![self.data.contentType isEqualToString:@"html"]
+        || self.webView == nil
+        || self.htmlTouchableRectsDidChangeBlock == nil) {
+        return;
+    }
+
+    NSString *script =
+    @"(function() {"
+    @"var selector = 'a, button, input, select, textarea, label, summary, [onclick], [role=\"button\"], [role=\"link\"], [data-action], [data-cp-action]';"
+    @"var interactiveNamePattern = /(button|btn|cta|link|close|submit|action|click)/i;"
+    @"var contentTags = /^(img|svg|canvas|video|audio|iframe)$/i;"
+    @"function colorHasAlpha(color) {"
+    @"if (!color || color === 'transparent') { return false; }"
+    @"var match = color.match(/rgba?\\(([^)]+)\\)/);"
+    @"if (!match) { return true; }"
+    @"var parts = match[1].split(',').map(function(part) { return part.trim(); });"
+    @"return parts.length < 4 || parseFloat(parts[3]) > 0;"
+    @"}"
+    @"var visualViewport = window.visualViewport;"
+    @"var viewportOffsetLeft = visualViewport ? visualViewport.offsetLeft : 0;"
+    @"var viewportOffsetTop = visualViewport ? visualViewport.offsetTop : 0;"
+    @"function nativeRectPayload(rect, tag, name, reason) {"
+    @"return { left: rect.left - viewportOffsetLeft, top: rect.top - viewportOffsetTop, width: rect.width, height: rect.height, tag: tag, name: name, reason: reason };"
+    @"}"
+    @"var elements = Array.prototype.slice.call(document.querySelectorAll('*'));"
+    @"var rects = [];"
+    @"var contentBounds = null;"
+    @"function addToContentBounds(rect) {"
+    @"if (!contentBounds) { contentBounds = { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom }; return; }"
+    @"contentBounds.left = Math.min(contentBounds.left, rect.left);"
+    @"contentBounds.top = Math.min(contentBounds.top, rect.top);"
+    @"contentBounds.right = Math.max(contentBounds.right, rect.right);"
+    @"contentBounds.bottom = Math.max(contentBounds.bottom, rect.bottom);"
+    @"}"
+    @"elements.forEach(function(el) {"
+    @"var style = window.getComputedStyle(el);"
+    @"if (!style || style.display === 'none' || style.visibility === 'hidden' || style.pointerEvents === 'none' || style.opacity === '0') { return; }"
+    @"var tag = (el.tagName || '').toLowerCase();"
+    @"var name = ((el.className && el.className.baseVal) || el.className || '') + ' ' + (el.id || '');"
+    @"var isInteractive = el.matches(selector) || typeof el.onclick === 'function' || style.cursor === 'pointer' || interactiveNamePattern.test(name);"
+    @"var hasVisibleContent = contentTags.test(tag) || (el.children.length === 0 && ((el.textContent || '').trim().length > 0));"
+    @"var borderWidth = parseFloat(style.borderTopWidth || '0') + parseFloat(style.borderRightWidth || '0') + parseFloat(style.borderBottomWidth || '0') + parseFloat(style.borderLeftWidth || '0');"
+    @"var hasVisualBox = colorHasAlpha(style.backgroundColor) || style.backgroundImage !== 'none' || borderWidth > 0 || style.boxShadow !== 'none';"
+    @"var rect = el.getBoundingClientRect();"
+    @"if (rect.width <= 0 || rect.height <= 0 || rect.bottom < 0 || rect.right < 0 || rect.top > window.innerHeight || rect.left > window.innerWidth) { return; }"
+    @"if ((tag === 'html' || tag === 'body') || (!isInteractive && rect.width >= window.innerWidth * 0.95 && rect.height >= window.innerHeight * 0.95)) { return; }"
+    @"var pseudoBefore = window.getComputedStyle(el, '::before');"
+    @"var pseudoAfter = window.getComputedStyle(el, '::after');"
+    @"var hasPseudoContent = (pseudoBefore && pseudoBefore.content && pseudoBefore.content !== 'none' && pseudoBefore.content !== 'normal') || (pseudoAfter && pseudoAfter.content && pseudoAfter.content !== 'none' && pseudoAfter.content !== 'normal');"
+    @"var looksLikeControl = rect.width >= 8 && rect.height >= 8 && rect.width <= 180 && rect.height <= 180 && (style.position === 'absolute' || style.position === 'fixed' || parseInt(style.zIndex, 10) > 0 || hasPseudoContent);"
+    @"if (!isInteractive && !hasVisibleContent && !hasVisualBox && !looksLikeControl) { return; }"
+    @"addToContentBounds(rect);"
+    @"var reason = isInteractive ? 'interactive' : (hasVisibleContent ? 'content' : (hasVisualBox ? 'visual' : 'control-candidate'));"
+    @"rects.push(nativeRectPayload(rect, tag, name.trim(), reason));"
+    @"});"
+    @"if (contentBounds) {"
+    @"rects.unshift({ left: contentBounds.left - viewportOffsetLeft, top: contentBounds.top - viewportOffsetTop, width: Math.max(0, contentBounds.right - contentBounds.left), height: Math.max(0, contentBounds.bottom - contentBounds.top), tag: 'content-bounds', name: '', reason: 'content-bounds' });"
+    @"var closeZoneTop = contentBounds.top - 240;"
+    @"var closeZoneHeight = Math.max(0, contentBounds.top - closeZoneTop + 80);"
+    @"rects.unshift({ left: window.innerWidth - 112 - viewportOffsetLeft, top: closeZoneTop - viewportOffsetTop, width: 112, height: closeZoneHeight, tag: 'html-close-zone', name: '', reason: 'html-close-zone' });"
+    @"}"
+    @"return JSON.stringify(rects);"
+    @"})();";
+
+    __weak typeof(self) weakSelf = self;
+    [self.webView evaluateJavaScript:script completionHandler:^(id _Nullable result, NSError * _Nullable error) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (strongSelf == nil || strongSelf.htmlTouchableRectsDidChangeBlock == nil) {
+            return;
+        }
+
+        if (error != nil || ![result isKindOfClass:[NSString class]]) {
+            strongSelf.htmlTouchableRectsDidChangeBlock(@[[NSValue valueWithCGRect:strongSelf.webView.bounds]]);
+            return;
+        }
+
+        NSData *data = [(NSString *)result dataUsingEncoding:NSUTF8StringEncoding];
+        NSArray *rectDictionaries = nil;
+        if (data != nil) {
+            rectDictionaries = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+        }
+
+        if (![rectDictionaries isKindOfClass:[NSArray class]]) {
+            strongSelf.htmlTouchableRectsDidChangeBlock(@[[NSValue valueWithCGRect:strongSelf.webView.bounds]]);
+            return;
+        }
+
+        NSMutableArray<NSValue *> *touchableRects = [NSMutableArray array];
+        for (NSDictionary *rectDictionary in rectDictionaries) {
+            if (![rectDictionary isKindOfClass:[NSDictionary class]]) {
+                continue;
+            }
+
+            NSNumber *left = rectDictionary[@"left"];
+            NSNumber *top = rectDictionary[@"top"];
+            NSNumber *width = rectDictionary[@"width"];
+            NSNumber *height = rectDictionary[@"height"];
+            NSString *reason = rectDictionary[@"reason"];
+            if (![left isKindOfClass:[NSNumber class]] || ![top isKindOfClass:[NSNumber class]] ||
+                ![width isKindOfClass:[NSNumber class]] || ![height isKindOfClass:[NSNumber class]]) {
+                continue;
+            }
+
+            BOOL isContentBounds = [reason isKindOfClass:[NSString class]] && [reason isEqualToString:@"content-bounds"];
+            BOOL isHTMLCloseZone = [reason isKindOfClass:[NSString class]] && [reason isEqualToString:@"html-close-zone"];
+            CGRect rect = CGRectMake(left.doubleValue, top.doubleValue, width.doubleValue, height.doubleValue);
+            CGFloat rectInset = (isContentBounds || isHTMLCloseZone) ? -96.0 : -48.0;
+            rect = CGRectInset(rect, rectInset, rectInset);
+            [touchableRects addObject:[NSValue valueWithCGRect:rect]];
+        }
+
+        if (touchableRects.count == 0) {
+            [touchableRects addObject:[NSValue valueWithCGRect:strongSelf.webView.bounds]];
+        }
+
+        strongSelf.htmlTouchableRectsDidChangeBlock(touchableRects);
+    }];
+}
+
 #pragma mark - UIWebView Delgate Method
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
+    if (![CleverPush getAppBannersNonBlocking]) {
+        return;
+    }
+    if (webView == self.webView) {
+        [self updateHTMLBannerTouchableRects];
+    }
+}
+
 - (void)userContentController:(WKUserContentController*)userContentController
       didReceiveScriptMessage:(WKScriptMessage*)message {
     if (message != nil && message.body != nil && message.name != nil) {

--- a/CleverPush/Source/CPUtils.m
+++ b/CleverPush/Source/CPUtils.m
@@ -763,19 +763,36 @@ NSString * const localeIdentifier = @"en_US_POSIX";
     webView.contentMode = UIViewContentModeScaleToFill;
 }
 
++ (CPAppBannerViewController *)appBannerViewControllerForWebView:(WKWebView *)webView {
+    UIResponder *responder = webView;
+    while (responder != nil) {
+        if ([responder isKindOfClass:[CPAppBannerViewController class]]) {
+            return (CPAppBannerViewController *)responder;
+        }
+        responder = responder.nextResponder;
+    }
+    return nil;
+}
+
 + (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message withBanner:(CPAppBanner *)banner {
     [CPLog debug:@"Received message: %@ with body: %@", message.name, message.body];
 
     if (message != nil && message.name != nil) {
         if ([message.name isEqualToString:@"close"] || [message.name isEqualToString:@"closeBanner"]) {
-            UIViewController *topController = [CleverPush topViewController];
-            if (topController) {
-                [CPLog debug:@"Dismissing controller: %@", topController];
-                [topController dismissViewControllerAnimated:YES completion:^{
-                    [CPLog debug:@"Controller dismissed"];
-                }];
+            CPAppBannerViewController *bannerVC = [self appBannerViewControllerForWebView:message.webView];
+            if ([CleverPush getAppBannersNonBlocking] && bannerVC != nil) {
+                [CPLog debug:@"Dismissing non-blocking banner via onDismiss: %@", bannerVC];
+                [bannerVC onDismiss];
             } else {
-                [CPLog debug:@"No controller to dismiss"];
+                UIViewController *topController = [CleverPush topViewController];
+                if (topController) {
+                    [CPLog debug:@"Dismissing controller: %@", topController];
+                    [topController dismissViewControllerAnimated:YES completion:^{
+                        [CPLog debug:@"Controller dismissed"];
+                    }];
+                } else {
+                    [CPLog debug:@"No controller to dismiss"];
+                }
             }
         } else if ([message.name isEqualToString:@"nextScreen"]) {
             [[NSNotificationCenter defaultCenter] postNotificationName:@"NavigateToNextPageNotification" object:nil];
@@ -860,7 +877,26 @@ NSString * const localeIdentifier = @"en_US_POSIX";
             } else if ([message.name isEqualToString:@"openWebView"]) {
                 NSURL *webUrl = [NSURL URLWithString:[NSString stringWithFormat:@"%@", message.body]];
                 if (webUrl && webUrl.scheme && webUrl.host) {
-                    [self openSafari:webUrl dismissViewController:CleverPush.topViewController];
+                    CPAppBannerViewController *bannerVC =
+                    [self appBannerViewControllerForWebView:message.webView];
+                    if ([CleverPush getAppBannersNonBlocking] && bannerVC != nil) {
+                        [bannerVC onDismiss];
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            SFSafariViewController *safariController =
+                            [[SFSafariViewController alloc] initWithURL:webUrl];
+                            
+                            safariController.modalPresentationStyle =
+                            UIModalPresentationPageSheet;
+                            
+                            [CleverPush.topViewController
+                             presentViewController:safariController
+                             animated:YES
+                             completion:nil];
+                        });
+                    } else {
+                        [self openSafari:webUrl
+                   dismissViewController:CleverPush.topViewController];
+                    }
                 }
             } else if ([message.name isEqualToString:@"goToScreen"]) {
                 if (message.name != nil && [message.name isKindOfClass:[NSString class]]) {

--- a/CleverPush/Source/CleverPush.h
+++ b/CleverPush/Source/CleverPush.h
@@ -91,6 +91,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 + (void)enableAppBanners;
 + (void)setAppBannerTrackingEnabled:(BOOL)enabled;
 + (void)setAppBannersNonBlocking:(BOOL)nonBlocking;
++ (BOOL)getAppBannersNonBlocking;
 + (BOOL)popupVisible;
 + (void)unsubscribe;
 + (void)unsubscribe:(void(^ _Nullable)(BOOL))callback;

--- a/CleverPush/Source/CleverPush.m
+++ b/CleverPush/Source/CleverPush.m
@@ -232,6 +232,10 @@ static CleverPush* singleInstance = nil;
     [self.CPSharedInstance setAppBannersNonBlocking:nonBlocking];
 }
 
++ (BOOL)getAppBannersNonBlocking {
+    return [self.CPSharedInstance getAppBannersNonBlocking];
+}
+
 + (BOOL)popupVisible {
     return [self.CPSharedInstance popupVisible];
 }

--- a/CleverPush/Source/CleverPushInstance.h
+++ b/CleverPush/Source/CleverPushInstance.h
@@ -124,6 +124,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 - (void)enableAppBanners;
 - (void)setAppBannerTrackingEnabled:(BOOL)enabled;
 - (void)setAppBannersNonBlocking:(BOOL)nonBlocking;
+- (BOOL)getAppBannersNonBlocking;
 - (BOOL)popupVisible;
 - (void)unsubscribe;
 - (void)unsubscribe:(void(^ _Nullable)(BOOL))callback;

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -4690,6 +4690,10 @@ static id isNil(id object) {
     [CPAppBannerModule setAppBannersNonBlocking:nonBlocking];
 }
 
+- (BOOL)getAppBannersNonBlocking {
+    return [CPAppBannerModule getAppBannersNonBlocking];
+}
+
 - (BOOL)getAppBannerDraftsEnabled {
     return isShowDraft;
 }


### PR DESCRIPTION
Resolved the issue of HTML buttons were not working when setAppBannersNonBlocking is true.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hit-testing and WKWebView script-message dismiss flows for non-blocking HTML banners only; wrong rects could block taps or leak touches to the app underneath.
> 
> **Overview**
> Fixes **HTML app banner links and buttons** when **`setAppBannersNonBlocking(true)`** by routing touches only to real banner content instead of blocking the whole overlay.
> 
> **Touchable regions:** `CPAppBannerViewController` runs JavaScript after load (and on rotation) to find interactive/visible DOM areas, then pushes inset rects to the passthrough overlay via `htmlTouchableRectsDidChangeBlock`. `CPAppBannerPassthroughView` gains HTML mode (`htmlTouchPassthroughEnabled`, `webViewTouchableRects`) so hits outside those rects pass through to the app; close button and nested `WKWebView` lookup are handled explicitly.
> 
> **Script bridge:** Exposes **`getAppBannersNonBlocking`** on the public API. `CPUtils` resolves the banner VC from the message web view and, in non-blocking mode, uses **`onDismiss`** for close/`openWebView` instead of dismissing the top modal—so links and in-banner actions work with the child-VC presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c73ab7f627e0c9cb0789628faba7eeb35e33491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS HTML links and buttons not responding in non-blocking app banners. Addresses Linear CP-11872 by enabling proper touch passthrough and opening links as expected.

- **Bug Fixes**
  - Added detection of interactive HTML rects in the banner `WKWebView` and passthrough them via the overlay.
  - Improved hit testing to prioritize `WKWebView` and close controls; enabled HTML-specific passthrough mode.
  - Dismiss non-blocking banners via `onDismiss` for `close` and `openWebView`, then present `SFSafariViewController`.
  - Recalculate touchable rects on web view load and device rotation.
  - Introduced `getAppBannersNonBlocking` and wired it through `CleverPush` and module layers.

<sup>Written for commit 9c73ab7f627e0c9cb0789628faba7eeb35e33491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

