### PR TITLE
feature/cp-11669-add-button-border-customization-for-in-app-banners-ios

### DIFF
--- a/CleverPush.xcodeproj/project.pbxproj
+++ b/CleverPush.xcodeproj/project.pbxproj
@@ -54,6 +54,9 @@
 		2906A2C625857E680078FD61 /* CPUIBlockButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906A2C525857E680078FD61 /* CPUIBlockButton.m */; };
 		2906A2C725857E680078FD61 /* CPUIBlockButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906A2C525857E680078FD61 /* CPUIBlockButton.m */; };
 		2906A2D125857E910078FD61 /* CPUIBlockButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 2906A2D025857E900078FD61 /* CPUIBlockButton.h */; };
+		CB000000000000000000A003 /* CPBorderObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = CB000000000000000000A001 /* CPBorderObserver.m */; };
+		CB000000000000000000A004 /* CPBorderObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = CB000000000000000000A001 /* CPBorderObserver.m */; };
+		CB000000000000000000A005 /* CPBorderObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = CB000000000000000000A002 /* CPBorderObserver.h */; };
 		2907D0F5286E13BB00C7C4E0 /* NSMutableArray+ContainsString.m in Sources */ = {isa = PBXBuildFile; fileRef = 2907D0F4286E13BB00C7C4E0 /* NSMutableArray+ContainsString.m */; };
 		2907D0F6286E13BB00C7C4E0 /* NSMutableArray+ContainsString.m in Sources */ = {isa = PBXBuildFile; fileRef = 2907D0F4286E13BB00C7C4E0 /* NSMutableArray+ContainsString.m */; };
 		2907D0F8286E13EE00C7C4E0 /* NSMutableArray+ContainsString.h in Headers */ = {isa = PBXBuildFile; fileRef = 2907D0F7286E13EE00C7C4E0 /* NSMutableArray+ContainsString.h */; };
@@ -433,6 +436,8 @@
 		290187F527C1020200535617 /* CleverPushUserDefaults.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CleverPushUserDefaults.h; sourceTree = "<group>"; };
 		2906A2C525857E680078FD61 /* CPUIBlockButton.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CPUIBlockButton.m; sourceTree = "<group>"; };
 		2906A2D025857E900078FD61 /* CPUIBlockButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CPUIBlockButton.h; sourceTree = "<group>"; };
+		CB000000000000000000A001 /* CPBorderObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CPBorderObserver.m; sourceTree = "<group>"; };
+		CB000000000000000000A002 /* CPBorderObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CPBorderObserver.h; sourceTree = "<group>"; };
 		2907D0F4286E13BB00C7C4E0 /* NSMutableArray+ContainsString.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSMutableArray+ContainsString.m"; sourceTree = "<group>"; };
 		2907D0F7286E13EE00C7C4E0 /* NSMutableArray+ContainsString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSMutableArray+ContainsString.h"; sourceTree = "<group>"; };
 		2913D82C25141324002BA52C /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.16.sdk/System/iOSSupport/System/Library/Frameworks/WebKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -995,6 +1000,8 @@
 				29D9052B25698B7F002D6F9E /* CPTranslate.m */,
 				2906A2D025857E900078FD61 /* CPUIBlockButton.h */,
 				2906A2C525857E680078FD61 /* CPUIBlockButton.m */,
+				CB000000000000000000A002 /* CPBorderObserver.h */,
+				CB000000000000000000A001 /* CPBorderObserver.m */,
 				298F4FC225002DA400F086D3 /* CPUtils.h */,
 				298F4FC025002D6700F086D3 /* CPUtils.m */,
 				CB88F8FE262FE91E0037787E /* CPWKWebKitView.h */,
@@ -1252,6 +1259,7 @@
 				CBA989A22679D61F003DE995 /* CPStoriesController.h in Headers */,
 				935A5F172AE64FB7007A3F7F /* CPSQLiteManager.h in Headers */,
 				2906A2D125857E910078FD61 /* CPUIBlockButton.h in Headers */,
+				CB000000000000000000A005 /* CPBorderObserver.h in Headers */,
 				2906A10B258557610078FD61 /* CPAppBannerDismissType.h in Headers */,
 				9310FD682A602D1F004B400B /* CPInboxDetailView.h in Headers */,
 				29AD0C5C26682A92009E10D0 /* CPAppBannerHTMLBlock.h in Headers */,
@@ -1616,6 +1624,7 @@
 				29DC4AC4218208730051F6E9 /* UIApplicationDelegate+CleverPush.m in Sources */,
 				29BB7E2128F5A19F0022426E /* NSString+VersionComparator.m in Sources */,
 				2906A2C625857E680078FD61 /* CPUIBlockButton.m in Sources */,
+				CB000000000000000000A003 /* CPBorderObserver.m in Sources */,
 				297810C52573E44B0083D1A6 /* CPAppBannerBackground.m in Sources */,
 				297810CE2573E44D0083D1A6 /* CPAppBannerButtonBlock.m in Sources */,
 				29DB578623D4D61F0040E823 /* CPNotificationCategoryController.m in Sources */,
@@ -1702,6 +1711,7 @@
 				291FCD282525DC2800F5185E /* DWActionsStackView.m in Sources */,
 				298676712572CC400002E9F1 /* CPAppBannerModule.m in Sources */,
 				2906A2C725857E680078FD61 /* CPUIBlockButton.m in Sources */,
+				CB000000000000000000A004 /* CPBorderObserver.m in Sources */,
 				CB1B65C62757763B0087AC49 /* CleverPushInstance.m in Sources */,
 				296D0AD7257460E800531EFF /* UIControl+CPBlockActions.m in Sources */,
 				29DB95F823FC33D6008FC985 /* CleverPushHTTPClient.m in Sources */,

--- a/CleverPush/Source/CPAppBannerButtonBlock.h
+++ b/CleverPush/Source/CPAppBannerButtonBlock.h
@@ -16,8 +16,11 @@
 @property (nonatomic, strong) NSString *darkBackground;
 @property (nonatomic, strong) NSString *family;
 @property (nonatomic, strong) NSString *id;
+@property (nonatomic, strong) NSString *borderColor;
+@property (nonatomic, strong) NSString *borderStyle;
 @property (nonatomic) int size;
 @property (nonatomic) int radius;
+@property (nonatomic) int borderWidth;
 @property (assign) BOOL isButtonClicked;
 
 #pragma mark - Class Methods

--- a/CleverPush/Source/CPAppBannerButtonBlock.m
+++ b/CleverPush/Source/CPAppBannerButtonBlock.m
@@ -58,6 +58,21 @@
         if ([json objectForKey:@"id"]) {
             self.id = [json objectForKey:@"id"];
         }
+
+        self.borderWidth = 0;
+        if ([json objectForKey:@"radius"]) {
+            self.borderWidth = [[json cleverPushNumberForKey:@"borderWidth"] intValue];
+        }
+        
+        self.borderColor = @"";
+        if ([json cleverPushStringForKey:@"borderColor"]) {
+            self.borderColor = [json cleverPushStringForKey:@"borderColor"];
+        }
+
+        self.borderStyle = @"";
+        if ([json cleverPushStringForKey:@"borderStyle"]) {
+            self.borderStyle = [json cleverPushStringForKey:@"borderStyle"];
+        }
         
         NSMutableDictionary *buttonBlockDic = [[NSMutableDictionary alloc] init];
         buttonBlockDic = [[json objectForKey:@"action"] mutableCopy];

--- a/CleverPush/Source/CPAppBannerButtonBlock.m
+++ b/CleverPush/Source/CPAppBannerButtonBlock.m
@@ -60,7 +60,7 @@
         }
 
         self.borderWidth = 0;
-        if ([json objectForKey:@"radius"]) {
+        if ([json objectForKey:@"borderWidth"]) {
             self.borderWidth = [[json cleverPushNumberForKey:@"borderWidth"] intValue];
         }
         

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -13,6 +13,7 @@
 #import "CPAppBannerCarouselBlock.h"
 #import "CPLog.h"
 #import "CPUtils.h"
+#import "CPBorderObserver.h"
 
 @implementation CPBannerCardContainer
 @synthesize delegate;
@@ -349,6 +350,20 @@
         cell.btnCPBanner.contentEdgeInsets = UIEdgeInsetsMake(15.0, 15.0, 15.0, 15.0);
         cell.btnCPBanner.translatesAutoresizingMaskIntoConstraints = false;
         cell.btnCPBanner.layer.cornerRadius = (CGFloat)block.radius * 0.6;
+
+        CGFloat borderWidth = (CGFloat)block.borderWidth * 0.6;
+        UIColor *borderColor;
+        if (block.borderColor != nil && ![block.borderColor isEqualToString:@""]) {
+            borderColor = [UIColor colorWithHexString:block.borderColor];
+        } else {
+            borderColor = [UIColor whiteColor];
+        }
+        [CPBorderObserver applyBorderToView:cell.btnCPBanner
+                                      width:borderWidth
+                                      color:borderColor
+                                      style:block.borderStyle
+                               cornerRadius:cell.btnCPBanner.layer.cornerRadius];
+
         cell.btnCPBanner.adjustsImageWhenHighlighted = YES;
         cell.btnCPBanner.titleLabel.numberOfLines = 0;
         cell.btnCPBanner.titleLabel.textAlignment = NSTextAlignmentCenter;

--- a/CleverPush/Source/CPBorderObserver.h
+++ b/CleverPush/Source/CPBorderObserver.h
@@ -1,0 +1,12 @@
+#import <UIKit/UIKit.h>
+
+#pragma mark - Keeps a view's solid / dashed / dotted border in sync with its bounds
+@interface CPBorderObserver : NSObject
+
++ (void)applyBorderToView:(UIView *)view
+                    width:(CGFloat)width
+                    color:(UIColor *)color
+                    style:(NSString *)style
+             cornerRadius:(CGFloat)cornerRadius;
+
+@end

--- a/CleverPush/Source/CPBorderObserver.h
+++ b/CleverPush/Source/CPBorderObserver.h
@@ -1,12 +1,16 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 #pragma mark - Keeps a view's solid / dashed / dotted border in sync with its bounds
 @interface CPBorderObserver : NSObject
 
 + (void)applyBorderToView:(UIView *)view
                     width:(CGFloat)width
-                    color:(UIColor *)color
-                    style:(NSString *)style
+                    color:(nullable UIColor *)color
+                    style:(nullable NSString *)style
              cornerRadius:(CGFloat)cornerRadius;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CleverPush/Source/CPBorderObserver.m
+++ b/CleverPush/Source/CPBorderObserver.m
@@ -10,7 +10,7 @@ static const void *CPBorderObserverKey = &CPBorderObserverKey;
 @property (nonatomic, strong) CAShapeLayer *borderLayer;
 @property (nonatomic) CGFloat width;
 @property (nonatomic, strong) UIColor *color;
-@property (nonatomic, strong) NSString *style;
+@property (nonatomic, copy) NSString *style;
 @property (nonatomic) CGFloat cornerRadius;
 
 - (instancetype)initWithView:(UIView *)view;

--- a/CleverPush/Source/CPBorderObserver.m
+++ b/CleverPush/Source/CPBorderObserver.m
@@ -1,0 +1,128 @@
+#import "CPBorderObserver.h"
+#import <objc/runtime.h>
+
+static const void *CPBorderObserverKey = &CPBorderObserverKey;
+
+@interface CPBorderObserver ()
+
+@property (nonatomic, weak) UIView *view;
+@property (nonatomic, strong) CALayer *observedLayer;
+@property (nonatomic, strong) CAShapeLayer *borderLayer;
+@property (nonatomic) CGFloat width;
+@property (nonatomic, strong) UIColor *color;
+@property (nonatomic, strong) NSString *style;
+@property (nonatomic) CGFloat cornerRadius;
+
+- (instancetype)initWithView:(UIView *)view;
+- (void)apply;
+
+@end
+
+@implementation CPBorderObserver
+
++ (void)applyBorderToView:(UIView *)view
+                    width:(CGFloat)width
+                    color:(UIColor *)color
+                    style:(NSString *)style
+             cornerRadius:(CGFloat)cornerRadius {
+    if (view == nil) {
+        return;
+    }
+    
+    CPBorderObserver *observer = objc_getAssociatedObject(view, CPBorderObserverKey);
+    if (observer == nil) {
+        observer = [[CPBorderObserver alloc] initWithView:view];
+        objc_setAssociatedObject(view, CPBorderObserverKey, observer, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    
+    observer.width = width;
+    observer.color = color;
+    observer.style = style;
+    observer.cornerRadius = cornerRadius;
+    [observer apply];
+}
+
+- (instancetype)initWithView:(UIView *)view {
+    self = [super init];
+    if (self) {
+        _view = view;
+        _observedLayer = view.layer;
+        [_observedLayer addObserver:self forKeyPath:@"bounds" options:NSKeyValueObservingOptionNew context:NULL];
+    }
+    return self;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context {
+    if ([keyPath isEqualToString:@"bounds"]) {
+        [self apply];
+    }
+}
+
+- (void)apply {
+    UIView *view = self.view;
+    if (view == nil) {
+        return;
+    }
+    
+    NSString *normalizedStyle = self.style ? [self.style lowercaseString] : @"";
+    BOOL isDashed = [normalizedStyle isEqualToString:@"dashed"];
+    BOOL isDotted = [normalizedStyle isEqualToString:@"dotted"];
+    
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    
+    if (self.width <= 0) {
+        view.layer.borderWidth = 0;
+        [self.borderLayer removeFromSuperlayer];
+        self.borderLayer = nil;
+        [CATransaction commit];
+        return;
+    }
+    
+    UIColor *borderColor = self.color != nil ? self.color : [UIColor whiteColor];
+    
+    if (isDashed || isDotted) {
+        view.layer.borderWidth = 0;
+        
+        if (self.borderLayer == nil) {
+            self.borderLayer = [CAShapeLayer layer];
+            self.borderLayer.fillColor = [UIColor clearColor].CGColor;
+            [view.layer addSublayer:self.borderLayer];
+        }
+        
+        CGFloat inset = self.width / 2.0;
+        CGRect borderRect = CGRectInset(view.bounds, inset, inset);
+        CGFloat pathRadius = MAX(self.cornerRadius - inset, 0);
+        UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:borderRect cornerRadius:pathRadius];
+        
+        self.borderLayer.frame = view.bounds;
+        self.borderLayer.path = path.CGPath;
+        self.borderLayer.lineWidth = self.width;
+        self.borderLayer.strokeColor = borderColor.CGColor;
+        
+        if (isDotted) {
+            self.borderLayer.lineCap = kCALineCapRound;
+            self.borderLayer.lineDashPattern = @[@(0.01), @(self.width * 2)];
+        } else {
+            self.borderLayer.lineCap = kCALineCapButt;
+            self.borderLayer.lineDashPattern = @[@(self.width * 3), @(self.width * 2)];
+        }
+    } else {
+        // solid (default)
+        [self.borderLayer removeFromSuperlayer];
+        self.borderLayer = nil;
+        view.layer.borderWidth = self.width;
+        view.layer.borderColor = borderColor.CGColor;
+    }
+    
+    [CATransaction commit];
+}
+
+- (void)dealloc {
+    [_observedLayer removeObserver:self forKeyPath:@"bounds"];
+}
+
+@end

--- a/CleverPush/Source/CPInboxDetailContainer.m
+++ b/CleverPush/Source/CPInboxDetailContainer.m
@@ -13,6 +13,7 @@
 #import "CPAppBannerCarouselBlock.h"
 #import "CPLog.h"
 #import "CPUtils.h"
+#import "CPBorderObserver.h"
 #import "CPInboxDetailContainer.h"
 
 @implementation CPInboxDetailContainer
@@ -154,6 +155,20 @@
         cell.btnCPBanner.contentEdgeInsets = UIEdgeInsetsMake(15.0, 15.0, 15.0, 15.0);
         cell.btnCPBanner.translatesAutoresizingMaskIntoConstraints = false;
         cell.btnCPBanner.layer.cornerRadius = (CGFloat)block.radius * 0.6;
+
+        CGFloat borderWidth = (CGFloat)block.borderWidth * 0.6;
+        UIColor *borderColor;
+        if (block.borderColor != nil && ![block.borderColor isEqualToString:@""]) {
+            borderColor = [UIColor colorWithHexString:block.borderColor];
+        } else {
+            borderColor = [UIColor whiteColor];
+        }
+        [CPBorderObserver applyBorderToView:cell.btnCPBanner
+                                      width:borderWidth
+                                      color:borderColor
+                                      style:block.borderStyle
+                               cornerRadius:cell.btnCPBanner.layer.cornerRadius];
+
         cell.btnCPBanner.adjustsImageWhenHighlighted = YES;
         cell.btnCPBanner.titleLabel.numberOfLines = 0;
         cell.btnCPBanner.titleLabel.textAlignment = NSTextAlignmentCenter;


### PR DESCRIPTION
Add configurable border (width, color, solid/dashed/dotted style) to banner buttons

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only banner styling with backward-compatible defaults; KVO on layer bounds is localized to border rendering.
> 
> **Overview**
> Adds **JSON-driven button borders** for in-app banner buttons on iOS (`borderWidth`, `borderColor`, `borderStyle`), wired through `CPAppBannerButtonBlock` and applied when rendering banner and inbox detail buttons.
> 
> `CPAppBannerButtonBlock` gains `borderWidth`, `borderColor`, and `borderStyle` parsed from banner JSON (defaults keep existing banners unchanged when width is 0).
> 
> A new **`CPBorderObserver`** helper attaches to each button view, draws **solid** borders via `CALayer` and **dashed/dotted** via `CAShapeLayer`, and **re-applies on bounds changes** (KVO). `CPBannerCardContainer` and `CPInboxDetailContainer` call it on `btnCPBanner` after corner radius is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f181aa915227863e856d50eab2991ca9eb694c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable borders to in‑app banner buttons on iOS (CP‑11669). Supports width, color, and solid/dashed/dotted styles, and keeps borders aligned with button bounds and corner radius.

- **New Features**
  - Added `borderWidth`, `borderColor`, `borderStyle` to `CPAppBannerButtonBlock` (JSON-driven).
  - Introduced `CPBorderObserver` to draw solid via `CALayer` and dashed/dotted via `CAShapeLayer`, reapplying on `bounds` changes.
  - Applied to `btnCPBanner` in `CPBannerCardContainer` and `CPInboxDetailContainer`; width scales by 0.6 like radius.

- **Migration**
  - JSON keys:
    - `borderWidth` (int, default 0 = no border)
    - `borderColor` (hex string, default white)
    - `borderStyle` ("solid" | "dashed" | "dotted", default "solid")
  - No breaking changes; banners render unchanged if `borderWidth` is 0.

<sup>Written for commit 3f181aa915227863e856d50eab2991ca9eb694c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

