### PR TITLE
hotfix/cp-11961-app-push-app-crash-in-cleverpushnotificationserviceextension

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -4907,8 +4907,20 @@ static id isNil(id object) {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
 
     if (![CPUtils isNullOrEmpty:request.identifier]) {
-        NSMutableDictionary* mutablePayload = [payload mutableCopy];
-        NSMutableDictionary* mutableNotification = [notification mutableCopy];
+        NSMutableDictionary* mutablePayload;
+        if (payload) {
+            mutablePayload = [payload mutableCopy];
+        } else {
+            mutablePayload = [[NSMutableDictionary alloc] init];
+        }
+
+        NSMutableDictionary* mutableNotification;
+        if (notification) {
+            mutableNotification = [notification mutableCopy];
+        } else {
+            mutableNotification = [[NSMutableDictionary alloc] init];
+        }
+
         [mutableNotification setObject:request.identifier forKey:@"notificationIdentifier"];
         [mutablePayload setObject:mutableNotification forKey:@"notification"];
         payload = [mutablePayload copy];


### PR DESCRIPTION
Optimize didReceiveNotificationExtensionRequest to safely handle nil notification objects and prevent crashes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in the extension notification handler; no auth or data-model changes, only avoids nil `mutableCopy` crashes.
> 
> **Overview**
> Fixes a crash in the **Notification Service Extension** path when handling `didReceiveNotificationExtensionRequest` with a non-empty `request.identifier`.
> 
> Previously, the handler always called `mutableCopy` on `payload` and the nested `notification` dictionary. When `userInfo` or the `notification` key was missing, that could crash before injecting `notificationIdentifier`.
> 
> The change **nil-checks** both values and falls back to freshly allocated `NSMutableDictionary` instances, then continues to set `notificationIdentifier` and reattach the nested `notification` object as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be741e0d00125219336546445c158f969218ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the notification service extension when a push arrives with a nil payload or notification. Guards against nil in `didReceiveNotificationExtensionRequest`, addressing CP-11961.

- **Bug Fixes**
  - Initialize empty mutable dictionaries for `payload` and `notification` when nil before setting `notificationIdentifier`, preventing crashes.

<sup>Written for commit 8be741e0d00125219336546445c158f969218ecf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

