### PR TITLE
hotfix/cp-11970-ios-in-app-banner-loses-context-after-openwebview-is

### DIFF
--- a/CleverPush/Source/CPUtils.m
+++ b/CleverPush/Source/CPUtils.m
@@ -877,26 +877,7 @@ NSString * const localeIdentifier = @"en_US_POSIX";
             } else if ([message.name isEqualToString:@"openWebView"]) {
                 NSURL *webUrl = [NSURL URLWithString:[NSString stringWithFormat:@"%@", message.body]];
                 if (webUrl && webUrl.scheme && webUrl.host) {
-                    CPAppBannerViewController *bannerVC =
-                    [self appBannerViewControllerForWebView:message.webView];
-                    if ([CleverPush getAppBannersNonBlocking] && bannerVC != nil) {
-                        [bannerVC onDismiss];
-                        dispatch_async(dispatch_get_main_queue(), ^{
-                            SFSafariViewController *safariController =
-                            [[SFSafariViewController alloc] initWithURL:webUrl];
-                            
-                            safariController.modalPresentationStyle =
-                            UIModalPresentationPageSheet;
-                            
-                            [CleverPush.topViewController
-                             presentViewController:safariController
-                             animated:YES
-                             completion:nil];
-                        });
-                    } else {
-                        [self openSafari:webUrl
-                   dismissViewController:CleverPush.topViewController];
-                    }
+                    [self openSafari:webUrl];
                 }
             } else if ([message.name isEqualToString:@"goToScreen"]) {
                 if (message.name != nil && [message.name isKindOfClass:[NSString class]]) {


### PR DESCRIPTION
Fixed issue in iOS in-app banner being dismissed when a WebView link triggers openWebView().

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX-focused change in the banner WebView bridge; no auth or data handling, though flows that depended on auto-dismiss before Safari will behave differently.
> 
> **Overview**
> Fixes **CP-11970** by changing how banner WebViews handle `CleverPush.openWebView()` from JavaScript.
> 
> The `openWebView` script message handler no longer resolves the hosting `CPAppBannerViewController`, calls `onDismiss` for non-blocking banners, or uses `openSafari:dismissViewController:` (which dismissed the top controller and cleared the banner-visible flag). It now always calls **`openSafari:`**, which presents `SFSafariViewController` over the current top controller **without** tearing down the banner first, so users can return to the in-app banner after viewing the link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4287d9e9dd717d43da5d22c9c04456c68209c1aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CP-11970: the iOS in‑app banner no longer loses context when a `WKWebView` link triggers `openWebView`. Links now open without dismissing the banner.

- **Bug Fixes**
  - Route `openWebView` to `openSafari:` directly and remove banner dismissal / direct `SFSafariViewController` presentation, preserving banner state when returning.

<sup>Written for commit 4287d9e9dd717d43da5d22c9c04456c68209c1aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

