### PR TITLE
feature/cp-11478-app-push-listen-to-beacons-and-trigger-an-event-ios

### DIFF
--- a/CleverPushLocation/Source/CleverPushLocation.h
+++ b/CleverPushLocation/Source/CleverPushLocation.h
@@ -1,11 +1,17 @@
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
 
+typedef void(^CPBeaconDetectedHandler)(NSDictionary *beacon);
+
 @interface CleverPushLocation : NSObject <CLLocationManagerDelegate>
 
 + (void)init;
 + (void)initBeacons;
++ (void)onBeaconDetected:(CPBeaconDetectedHandler)handler;
++ (void)setBeaconEventInterval:(NSInteger)minutes;
++ (void)setBeaconDebugScanAll:(BOOL)enabled;
 + (void)requestLocationPermission;
++ (BOOL)hasLocationPermission;
 + (void)trackBeaconEvent:(NSDictionary *)beacon;
 
 @end

--- a/CleverPushLocation/Source/CleverPushLocation.h
+++ b/CleverPushLocation/Source/CleverPushLocation.h
@@ -5,5 +5,6 @@
 
 + (void)init;
 + (void)requestLocationPermission;
++ (void)trackBeaconEvent:(NSDictionary *)beacon;
 
 @end

--- a/CleverPushLocation/Source/CleverPushLocation.h
+++ b/CleverPushLocation/Source/CleverPushLocation.h
@@ -4,6 +4,7 @@
 @interface CleverPushLocation : NSObject <CLLocationManagerDelegate>
 
 + (void)init;
++ (void)initBeacons;
 + (void)requestLocationPermission;
 + (void)trackBeaconEvent:(NSDictionary *)beacon;
 

--- a/CleverPushLocation/Source/CleverPushLocation.m
+++ b/CleverPushLocation/Source/CleverPushLocation.m
@@ -11,6 +11,7 @@ NSTimer *geoFenceTimer;
 double geoFenceTimerDelay;
 bool geoFenceTimeoutCompleted;
 NSMutableArray *delayedGeoFences;
+NSMutableArray *beacons;
 NSString* geoFenceEnterState = @"enter";
 NSString* geoFenceExitState = @"exit";
 double geoFenceTimerInterval = 1.0;
@@ -23,12 +24,13 @@ double geoFenceTimerInterval = 1.0;
             }
             [CleverPush getChannelConfig:^(NSDictionary* channelConfig) {
                 dispatch_async(dispatch_get_main_queue(), ^{
+                    if (!locationManager) {
+                        locationManager = [CLLocationManager new];
+                    }
+                    locationManager.delegate = (id)self;
+                    
                     NSArray* geoFencesDict = [channelConfig cleverPushArrayForKey:@"geoFences"];
                     if (channelConfig != nil && geoFencesDict != nil && [geoFencesDict count] > 0) {
-                        if (!locationManager) {
-                            locationManager = [CLLocationManager new];
-                        }
-                        locationManager.delegate = (id)self;
                         [geoFenceTimer invalidate];
                         geoFenceTimerDelay = 0;
                         geoFenceTimeoutCompleted = false;
@@ -53,6 +55,47 @@ double geoFenceTimerInterval = 1.0;
                                 }
                             }
                         }
+                    }
+                    
+                    NSArray* beaconsDict = [channelConfig cleverPushArrayForKey:@"beacons"];
+                    beacons = [[NSMutableArray alloc] init];
+                    if (@available(iOS 13.0, *)) {
+                        if (channelConfig != nil && beaconsDict != nil && [beaconsDict count] > 0) {
+                            for (NSDictionary *beacon in beaconsDict) {
+                                if (beacon == nil) continue;
+
+                                NSString *uuidString = [beacon objectForKey:@"uuid"];
+                                NSString *beaconId   = [beacon valueForKey:@"_id"];
+                                if (!uuidString || !beaconId) continue;
+
+                                NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+                                if (!uuid) continue;
+
+                                NSNumber *majorValue = [beacon objectForKey:@"major"];
+                                NSNumber *minorValue = [beacon objectForKey:@"minor"];
+
+                                CLBeaconRegion *region = nil;
+                                if (majorValue && minorValue) {
+                                    region = [[CLBeaconRegion alloc] initWithUUID:uuid major:[majorValue unsignedShortValue] minor:[minorValue unsignedShortValue] identifier:beaconId];
+                                } else if (majorValue) {
+                                    region = [[CLBeaconRegion alloc] initWithUUID:uuid major:[majorValue unsignedShortValue] identifier:beaconId];
+                                } else {
+                                    region = [[CLBeaconRegion alloc] initWithUUID:uuid identifier:beaconId];
+                                }
+
+                                if (region == nil) continue;
+
+                                region.notifyOnEntry = YES;
+                                region.notifyOnExit = YES;
+                                region.notifyEntryStateOnDisplay = YES;
+
+                                [beacons addObject:beacon];
+                                [locationManager startMonitoringForRegion:region];
+                                [CPLog info:@"CleverPushLocation: Started monitoring beacon %@ (UUID: %@)", beaconId, uuidString];
+                            }
+                        }
+                    } else {
+                        [CPLog info:@"CleverPushLocation: Beacon monitoring requires iOS 13.0 or later."];
                     }
                 });
             }];
@@ -97,6 +140,49 @@ double geoFenceTimerInterval = 1.0;
     });
 }
 
+#pragma mark - Track beacon
++ (void)trackBeaconEvent:(NSDictionary *)beacon {
+    NSString *eventName = [beacon objectForKey:@"eventName"];
+    if (!eventName) {
+        [CPLog error:@"CleverPushLocation: trackBeaconEvent: eventName is nil"];
+        return;
+    }
+    [CPLog info:@"CleverPushLocation: trackBeaconEvent - eventName: %@", eventName];
+    [CleverPush trackEvent:eventName];
+}
+
+#pragma mark - Beacon matching
++ (NSDictionary *)findMatchingBeaconForRegion:(CLBeaconRegion *)beaconRegion {
+    if (beaconRegion == nil || beacons.count == 0) return nil;
+
+    if (@available(iOS 13.0, *)) {
+        NSString *detectedUUID = beaconRegion.UUID.UUIDString;
+        [CPLog info:@"CleverPushLocation: findMatchingBeacon - detected uuid: %@, major: %@, minor: %@",
+         detectedUUID, beaconRegion.major, beaconRegion.minor];
+
+        for (NSDictionary *storedBeacon in beacons) {
+            NSString *storedUUID  = [storedBeacon objectForKey:@"uuid"];
+            NSNumber *storedMajor = [storedBeacon objectForKey:@"major"];
+            NSNumber *storedMinor = [storedBeacon objectForKey:@"minor"];
+
+            BOOL uuidMatch  = [storedUUID caseInsensitiveCompare:detectedUUID] == NSOrderedSame;
+            BOOL majorMatch = storedMajor ? ([storedMajor unsignedShortValue] == [beaconRegion.major unsignedShortValue]) : YES;
+            BOOL minorMatch = storedMinor ? ([storedMinor unsignedShortValue] == [beaconRegion.minor unsignedShortValue]) : YES;
+
+            [CPLog info:@"CleverPushLocation: Comparing - storedUUID: %@, uuidMatch: %d, majorMatch: %d, minorMatch: %d",
+             storedUUID, uuidMatch, majorMatch, minorMatch];
+
+            if (uuidMatch && majorMatch && minorMatch) {
+                [CPLog info:@"CleverPushLocation: Beacon matched - %@", [storedBeacon objectForKey:@"_id"]];
+                return storedBeacon;
+            }
+        }
+
+        [CPLog info:@"CleverPushLocation: No matching beacon found for uuid: %@", detectedUUID];
+    }
+    return nil;
+}
+
 #pragma mark - Location delegates
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
     [CPLog info:@"LocationManager: didChangeAuthorizationStatus %d", status];
@@ -116,33 +202,59 @@ double geoFenceTimerInterval = 1.0;
 }
 
 + (void)locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
-    [CPLog info:@"LocationManager: Entered Geo Fence %@", [region identifier]];
-    if (geoFenceTimeoutCompleted  == false) {
-        [geoFenceTimer invalidate];
-        geoFenceTimerDelay = 0;
-        geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval
-                                                         target:self
-                                                       selector:@selector(geoFenceHandleTimer:)
-                                                       userInfo:nil
-                                                        repeats:YES];
+    if ([region isKindOfClass:[CLBeaconRegion class]]) {
+        CLBeaconRegion *beaconRegion = (CLBeaconRegion *)region;
+        if (@available(iOS 13.0, *)) {
+            [CPLog info:@"LocationManager: Entered Beacon region - uuid: %@", beaconRegion.UUID.UUIDString];
+            NSDictionary *matchedBeacon = [self findMatchingBeaconForRegion:beaconRegion];
+            if (matchedBeacon) {
+                [self trackBeaconEvent:matchedBeacon];
+            }
+        }
     } else {
-        [self trackGeoFence:[region identifier] withState:geoFenceEnterState];
+        [CPLog info:@"LocationManager: Entered Geo Fence %@", [region identifier]];
+        if (geoFenceTimeoutCompleted == false) {
+            [geoFenceTimer invalidate];
+            geoFenceTimerDelay = 0;
+            geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval
+                                                             target:self
+                                                           selector:@selector(geoFenceHandleTimer:)
+                                                           userInfo:nil
+                                                            repeats:YES];
+        } else {
+            [self trackGeoFence:[region identifier] withState:geoFenceEnterState];
+        }
     }
 }
 
 + (void)locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region {
-    [CPLog info:@"LocationManager: Exited Geo Fence %@", [region identifier]];
-    if (geoFenceTimeoutCompleted == false) {
-        [geoFenceTimer invalidate];
-        geoFenceTimerDelay = 0;
-        geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval
-                                                         target:self
-                                                       selector:@selector(geoFenceHandleTimer:)
-                                                       userInfo:nil
-                                                        repeats:YES];
+    if ([region isKindOfClass:[CLBeaconRegion class]]) {
+        CLBeaconRegion *beaconRegion = (CLBeaconRegion *)region;
+        if (@available(iOS 13.0, *)) {
+            [CPLog info:@"LocationManager: Exited Beacon region - uuid: %@", beaconRegion.UUID.UUIDString];
+            NSDictionary *matchedBeacon = [self findMatchingBeaconForRegion:beaconRegion];
+            if (matchedBeacon) {
+                [self trackBeaconEvent:matchedBeacon];
+            }
+        }
     } else {
-        [self trackGeoFence:[region identifier] withState:geoFenceExitState];
+        [CPLog info:@"LocationManager: Exited Geo Fence %@", [region identifier]];
+        if (geoFenceTimeoutCompleted == false) {
+            [geoFenceTimer invalidate];
+            geoFenceTimerDelay = 0;
+            geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval
+                                                             target:self
+                                                           selector:@selector(geoFenceHandleTimer:)
+                                                           userInfo:nil
+                                                            repeats:YES];
+        } else {
+            [self trackGeoFence:[region identifier] withState:geoFenceExitState];
+        }
     }
+}
+
++ (void)locationManager:(CLLocationManager *)manager monitoringDidFailForRegion:(CLRegion *)region withError:(NSError *)error {
+    [CPLog error:@"LocationManager: monitoringDidFailForRegion %@ error: %@", [region identifier], error.localizedDescription];
 }
 
 + (void)geoFenceHandleTimer:(NSTimer *)timer {

--- a/CleverPushLocation/Source/CleverPushLocation.m
+++ b/CleverPushLocation/Source/CleverPushLocation.m
@@ -261,6 +261,16 @@ static BOOL beaconDebugScanAll = NO;
     return nil;
 }
 
++ (BOOL)geoFenceRegionHasDelay:(CLRegion *)region {
+    for (NSDictionary *geoFence in delayedGeoFences) {
+        CLRegion *r = [geoFence objectForKey:@"region"];
+        if ([[r identifier] isEqualToString:[region identifier]]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
 #pragma mark - Location delegates
 
 + (void)locationManager:(CLLocationManager *)manager didStartMonitoringForRegion:(CLRegion *)region {
@@ -306,7 +316,7 @@ static BOOL beaconDebugScanAll = NO;
         }
     } else {
         [CPLog info:@"LocationManager: Entered Geo Fence %@", [region identifier]];
-        if (geoFenceTimeoutCompleted == false && [delayedGeoFences count] > 0) {
+        if (geoFenceTimeoutCompleted == false && [self geoFenceRegionHasDelay:region]) {
             [geoFenceTimer invalidate];
             geoFenceTimerDelay = 0;
             geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval
@@ -335,7 +345,7 @@ static BOOL beaconDebugScanAll = NO;
         }
     } else {
         [CPLog info:@"LocationManager: Exited Geo Fence %@", [region identifier]];
-        if (geoFenceTimeoutCompleted == false && [delayedGeoFences count] > 0) {
+        if (geoFenceTimeoutCompleted == false && [self geoFenceRegionHasDelay:region]) {
             [geoFenceTimer invalidate];
             geoFenceTimerDelay = 0;
             geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval
@@ -354,17 +364,22 @@ static BOOL beaconDebugScanAll = NO;
 }
 
 + (void)geoFenceHandleTimer:(NSTimer *)timer {
+    NSMutableDictionary *expiredGeoFence = nil;
+    CLRegion *expiredRegion = nil;
     for (NSMutableDictionary *geoFence in delayedGeoFences) {
         if ([geoFence objectForKey:@"delay"] != nil) {
             double delayValue = [[geoFence objectForKey:@"delay"] doubleValue];
-            CLRegion *regionValue = [geoFence objectForKey:@"region"];
             if (geoFenceTimerDelay >= delayValue) {
                 geoFenceTimeoutCompleted = true;
-                [delayedGeoFences removeObject:geoFence];
-                [locationManager startMonitoringForRegion:regionValue];
+                expiredGeoFence = geoFence;
+                expiredRegion = [geoFence objectForKey:@"region"];
                 break;
             }
         }
+    }
+    if (expiredGeoFence) {
+        [delayedGeoFences removeObject:expiredGeoFence];
+        [locationManager startMonitoringForRegion:expiredRegion];
     }
     geoFenceTimerDelay += 1;
 }

--- a/CleverPushLocation/Source/CleverPushLocation.m
+++ b/CleverPushLocation/Source/CleverPushLocation.m
@@ -65,8 +65,8 @@ static BOOL beaconDebugScanAll = NO;
                                                                     region, @"region",
                                                                     nil];
                                     [delayedGeoFences addObject:dataDic];
-                                    [locationManager startMonitoringForRegion:region];
                                 }
+                                [locationManager startMonitoringForRegion:region];
                             }
                         }
                     }
@@ -231,9 +231,10 @@ static BOOL beaconDebugScanAll = NO;
     [CPLog info:@"CleverPushLocation: trackBeaconEvent - beaconId: %@, eventName: %@", beaconId, eventName];
     [CleverPush trackEvent:eventName];
 
-    if (beaconDetectedHandler) {
+    CPBeaconDetectedHandler handler = beaconDetectedHandler;
+    if (handler) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            beaconDetectedHandler(beacon);
+            handler(beacon);
         });
     }
 }
@@ -305,7 +306,7 @@ static BOOL beaconDebugScanAll = NO;
         }
     } else {
         [CPLog info:@"LocationManager: Entered Geo Fence %@", [region identifier]];
-        if (geoFenceTimeoutCompleted == false) {
+        if (geoFenceTimeoutCompleted == false && [delayedGeoFences count] > 0) {
             [geoFenceTimer invalidate];
             geoFenceTimerDelay = 0;
             geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval

--- a/CleverPushLocation/Source/CleverPushLocation.m
+++ b/CleverPushLocation/Source/CleverPushLocation.m
@@ -16,6 +16,13 @@ NSString* geoFenceEnterState = @"enter";
 NSString* geoFenceExitState = @"exit";
 double geoFenceTimerInterval = 1.0;
 
+static NSMutableDictionary *beaconLastFiredDate = nil;
+static CPBeaconDetectedHandler beaconDetectedHandler = nil;
+static NSTimeInterval beaconEventIntervalSec = 0;
+static BOOL beaconDebugScanAll = NO;
+
+#pragma mark - Geo-fence monitoring
+
 + (void)init {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^(void) {
         [CleverPush getSubscriptionId:^(NSString* subscriptionId) {
@@ -29,6 +36,13 @@ double geoFenceTimerInterval = 1.0;
                     }
                     locationManager.delegate = (id)self;
                     
+                    for (CLRegion *monitoredRegion in locationManager.monitoredRegions) {
+                        if ([monitoredRegion isKindOfClass:[CLCircularRegion class]]) {
+                            [locationManager stopMonitoringForRegion:monitoredRegion];
+                            [CPLog info:@"CleverPushLocation: Stopped stale geo-fence region %@", monitoredRegion.identifier];
+                        }
+                    }
+
                     NSArray* geoFencesDict = [channelConfig cleverPushArrayForKey:@"geoFences"];
                     if (channelConfig != nil && geoFencesDict != nil && [geoFencesDict count] > 0) {
                         [geoFenceTimer invalidate];
@@ -84,8 +98,10 @@ double geoFenceTimerInterval = 1.0;
                         }
                     }
 
-                    NSArray* beaconsDict = [channelConfig cleverPushArrayForKey:@"beacons"];
                     beacons = [[NSMutableArray alloc] init];
+                    beaconLastFiredDate = [[NSMutableDictionary alloc] init];
+
+                    NSArray* beaconsDict = [channelConfig cleverPushArrayForKey:@"beacons"];
                     if (@available(iOS 13.0, *)) {
                         if (channelConfig != nil && beaconsDict != nil && [beaconsDict count] > 0) {
                             for (NSDictionary *beacon in beaconsDict) {
@@ -109,7 +125,6 @@ double geoFenceTimerInterval = 1.0;
                                 } else {
                                     region = [[CLBeaconRegion alloc] initWithUUID:uuid identifier:beaconId];
                                 }
-
                                 if (region == nil) continue;
 
                                 region.notifyOnEntry = YES;
@@ -130,19 +145,38 @@ double geoFenceTimerInterval = 1.0;
     });
 }
 
-#pragma mark - Check the authority of location permission
-- (BOOL)hasLocationPermission {
+#pragma mark - Beacon configuration
+
++ (void)onBeaconDetected:(CPBeaconDetectedHandler)handler {
+    beaconDetectedHandler = handler ? [handler copy] : nil;
+    [CPLog info:@"CleverPushLocation: onBeaconDetected handler %@", handler ? @"registered" : @"cleared"];
+}
+
++ (void)setBeaconEventInterval:(NSInteger)minutes {
+    beaconEventIntervalSec = (minutes > 0) ? (minutes * 60.0) : 0;
+    [CPLog info:@"CleverPushLocation: beaconEventInterval set to %ld min(s)", (long)minutes];
+}
+
++ (void)setBeaconDebugScanAll:(BOOL)enabled {
+    beaconDebugScanAll = enabled;
+    [CPLog info:@"CleverPushLocation: beaconDebugScanAll = %@", enabled ? @"YES" : @"NO"];
+}
+
+#pragma mark - Location permission
+
++ (BOOL)hasLocationPermission {
     CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
     return status == kCLAuthorizationStatusAuthorizedAlways || status == kCLAuthorizationStatusAuthorizedWhenInUse;
 }
 
-#pragma mark - Request to access location permission
 + (void)requestLocationPermission {
     if (!locationManager) {
         locationManager = [CLLocationManager new];
     }
     [locationManager requestAlwaysAuthorization];
 }
+
+#pragma mark - Track geo-fence
 
 + (void)trackGeoFence:(NSString *)geoFenceId withState:(NSString *)state {
     dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
@@ -168,17 +202,44 @@ double geoFenceTimerInterval = 1.0;
 }
 
 #pragma mark - Track beacon
+
 + (void)trackBeaconEvent:(NSDictionary *)beacon {
     NSString *eventName = [beacon objectForKey:@"eventName"];
+    NSString *beaconId = [beacon valueForKey:@"_id"];
+
     if (!eventName) {
-        [CPLog error:@"CleverPushLocation: trackBeaconEvent: eventName is nil"];
+        [CPLog error:@"CleverPushLocation: trackBeaconEvent: eventName is nil for beacon %@", beaconId];
         return;
     }
-    [CPLog info:@"CleverPushLocation: trackBeaconEvent - eventName: %@", eventName];
+
+    if (!beaconDebugScanAll && beaconEventIntervalSec > 0 && beaconId) {
+        if (!beaconLastFiredDate) {
+            beaconLastFiredDate = [[NSMutableDictionary alloc] init];
+        }
+        NSDate *lastFired = beaconLastFiredDate[beaconId];
+        if (lastFired) {
+            NSTimeInterval elapsed = [[NSDate date] timeIntervalSinceDate:lastFired];
+            if (elapsed < beaconEventIntervalSec) {
+                [CPLog info:@"CleverPushLocation: Beacon %@ skipped - interval active (%.0fs remaining)",
+                 beaconId, beaconEventIntervalSec - elapsed];
+                return;
+            }
+        }
+        beaconLastFiredDate[beaconId] = [NSDate date];
+    }
+
+    [CPLog info:@"CleverPushLocation: trackBeaconEvent - beaconId: %@, eventName: %@", beaconId, eventName];
     [CleverPush trackEvent:eventName];
+
+    if (beaconDetectedHandler) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            beaconDetectedHandler(beacon);
+        });
+    }
 }
 
 #pragma mark - Beacon matching
+
 + (NSDictionary *)findMatchingBeaconForRegion:(CLBeaconRegion *)beaconRegion {
     if (beaconRegion == nil || beacons.count == 0) return nil;
 
@@ -193,22 +254,31 @@ double geoFenceTimerInterval = 1.0;
         }
     }
 
-    [CPLog info:@"CleverPushLocation: No matching beacon found for identifier: %@", regionIdentifier];
+    if (beaconDebugScanAll) {
+        [CPLog info:@"[BeaconDebug] No config match for identifier: %@", regionIdentifier];
+    }
     return nil;
 }
 
 #pragma mark - Location delegates
-- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
-    [CPLog info:@"LocationManager: didChangeAuthorizationStatus %d", status];
-}
 
 + (void)locationManager:(CLLocationManager *)manager didStartMonitoringForRegion:(CLRegion *)region {
     [CPLog info:@"LocationManager: didStartMonitoringForRegion %@", [region identifier]];
 }
 
 + (void)locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region {
-    [CPLog info:@"LocationManager: didDetermineState %@ - %@",
-     [region identifier], state == CLRegionStateInside ? @"Inside" : @"Outside"];
+    NSString *stateStr = (state == CLRegionStateInside) ? @"Inside" : (state == CLRegionStateOutside) ? @"Outside" : @"Unknown";
+
+    if (beaconDebugScanAll && [region isKindOfClass:[CLBeaconRegion class]]) {
+        if (@available(iOS 13.0, *)) {
+            CLBeaconRegion *br = (CLBeaconRegion *)region;
+            [CPLog info:@"[BeaconDebug] didDetermineState - identifier: %@, state: %@, uuid: %@, major: %@, minor: %@",
+             br.identifier, stateStr, br.UUID.UUIDString, br.major ?: @"-", br.minor ?: @"-"];
+        }
+    } else {
+        [CPLog info:@"LocationManager: didDetermineState %@ - %@", [region identifier], stateStr];
+    }
+
     if (state == CLRegionStateInside && ![region isKindOfClass:[CLBeaconRegion class]]) {
         [self locationManager:manager didEnterRegion:region];
     } else if (state == CLRegionStateOutside && ![region isKindOfClass:[CLBeaconRegion class]]) {
@@ -220,8 +290,14 @@ double geoFenceTimerInterval = 1.0;
     if ([region isKindOfClass:[CLBeaconRegion class]]) {
         if (@available(iOS 13.0, *)) {
             CLBeaconRegion *beaconRegion = (CLBeaconRegion *)region;
-            [CPLog info:@"LocationManager: Entered Beacon region - identifier: %@, uuid: %@",
-             beaconRegion.identifier, beaconRegion.UUID.UUIDString];
+            if (beaconDebugScanAll) {
+                [CPLog info:@"[BeaconDebug] didEnterRegion - identifier: %@, uuid: %@, major: %@, minor: %@",
+                 beaconRegion.identifier, beaconRegion.UUID.UUIDString,
+                 beaconRegion.major ?: @"-", beaconRegion.minor ?: @"-"];
+            } else {
+                [CPLog info:@"LocationManager: Entered Beacon region - identifier: %@, uuid: %@",
+                 beaconRegion.identifier, beaconRegion.UUID.UUIDString];
+            }
             NSDictionary *matchedBeacon = [self findMatchingBeaconForRegion:beaconRegion];
             if (matchedBeacon) {
                 [self trackBeaconEvent:matchedBeacon];
@@ -247,8 +323,14 @@ double geoFenceTimerInterval = 1.0;
     if ([region isKindOfClass:[CLBeaconRegion class]]) {
         if (@available(iOS 13.0, *)) {
             CLBeaconRegion *beaconRegion = (CLBeaconRegion *)region;
-            [CPLog info:@"LocationManager: Exited Beacon region - identifier: %@, uuid: %@",
-             beaconRegion.identifier, beaconRegion.UUID.UUIDString];
+            if (beaconDebugScanAll) {
+                [CPLog info:@"[BeaconDebug] didExitRegion - identifier: %@, uuid: %@, major: %@, minor: %@",
+                 beaconRegion.identifier, beaconRegion.UUID.UUIDString,
+                 beaconRegion.major ?: @"-", beaconRegion.minor ?: @"-"];
+            } else {
+                [CPLog info:@"LocationManager: Exited Beacon region - identifier: %@, uuid: %@",
+                 beaconRegion.identifier, beaconRegion.UUID.UUIDString];
+            }
         }
     } else {
         [CPLog info:@"LocationManager: Exited Geo Fence %@", [region identifier]];

--- a/CleverPushLocation/Source/CleverPushLocation.m
+++ b/CleverPushLocation/Source/CleverPushLocation.m
@@ -335,7 +335,7 @@ static BOOL beaconDebugScanAll = NO;
         }
     } else {
         [CPLog info:@"LocationManager: Exited Geo Fence %@", [region identifier]];
-        if (geoFenceTimeoutCompleted == false) {
+        if (geoFenceTimeoutCompleted == false && [delayedGeoFences count] > 0) {
             [geoFenceTimer invalidate];
             geoFenceTimerDelay = 0;
             geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval

--- a/CleverPushLocation/Source/CleverPushLocation.m
+++ b/CleverPushLocation/Source/CleverPushLocation.m
@@ -36,11 +36,13 @@ static BOOL beaconDebugScanAll = NO;
                     }
                     locationManager.delegate = (id)self;
                     
-                    for (CLRegion *monitoredRegion in locationManager.monitoredRegions) {
-                        if ([monitoredRegion isKindOfClass:[CLCircularRegion class]]) {
-                            [locationManager stopMonitoringForRegion:monitoredRegion];
-                            [CPLog info:@"CleverPushLocation: Stopped stale geo-fence region %@", monitoredRegion.identifier];
-                        }
+                    NSArray *staleGeoFenceRegions = [locationManager.monitoredRegions.allObjects filteredArrayUsingPredicate:
+                        [NSPredicate predicateWithBlock:^BOOL(id obj, NSDictionary *b) {
+                            return [obj isKindOfClass:[CLCircularRegion class]];
+                        }]];
+                    for (CLRegion *monitoredRegion in staleGeoFenceRegions) {
+                        [locationManager stopMonitoringForRegion:monitoredRegion];
+                        [CPLog info:@"CleverPushLocation: Stopped stale geo-fence region %@", monitoredRegion.identifier];
                     }
 
                     NSArray* geoFencesDict = [channelConfig cleverPushArrayForKey:@"geoFences"];
@@ -91,11 +93,13 @@ static BOOL beaconDebugScanAll = NO;
                     }
                     locationManager.delegate = (id)self;
 
-                    for (CLRegion *monitoredRegion in locationManager.monitoredRegions) {
-                        if ([monitoredRegion isKindOfClass:[CLBeaconRegion class]]) {
-                            [locationManager stopMonitoringForRegion:monitoredRegion];
-                            [CPLog info:@"CleverPushLocation: Stopped stale beacon region %@", monitoredRegion.identifier];
-                        }
+                    NSArray *staleBeaconRegions = [locationManager.monitoredRegions.allObjects filteredArrayUsingPredicate:
+                        [NSPredicate predicateWithBlock:^BOOL(id obj, NSDictionary *b) {
+                            return [obj isKindOfClass:[CLBeaconRegion class]];
+                        }]];
+                    for (CLRegion *monitoredRegion in staleBeaconRegions) {
+                        [locationManager stopMonitoringForRegion:monitoredRegion];
+                        [CPLog info:@"CleverPushLocation: Stopped stale beacon region %@", monitoredRegion.identifier];
                     }
 
                     beacons = [[NSMutableArray alloc] init];
@@ -114,8 +118,10 @@ static BOOL beaconDebugScanAll = NO;
                                 NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
                                 if (!uuid) continue;
 
-                                NSNumber *majorValue = [beacon objectForKey:@"major"];
-                                NSNumber *minorValue = [beacon objectForKey:@"minor"];
+                                id rawMajor = [beacon objectForKey:@"major"];
+                                id rawMinor = [beacon objectForKey:@"minor"];
+                                NSNumber *majorValue = [rawMajor isKindOfClass:[NSNumber class]] ? rawMajor : nil;
+                                NSNumber *minorValue = [rawMinor isKindOfClass:[NSNumber class]] ? rawMinor : nil;
 
                                 CLBeaconRegion *region = nil;
                                 if (majorValue && minorValue) {

--- a/CleverPushLocation/Source/CleverPushLocation.m
+++ b/CleverPushLocation/Source/CleverPushLocation.m
@@ -57,6 +57,13 @@ double geoFenceTimerInterval = 1.0;
                         }
                     }
                     
+                    for (CLRegion *monitoredRegion in locationManager.monitoredRegions) {
+                        if ([monitoredRegion isKindOfClass:[CLBeaconRegion class]]) {
+                            [locationManager stopMonitoringForRegion:monitoredRegion];
+                            [CPLog info:@"CleverPushLocation: Stopped stale beacon region %@", monitoredRegion.identifier];
+                        }
+                    }
+
                     NSArray* beaconsDict = [channelConfig cleverPushArrayForKey:@"beacons"];
                     beacons = [[NSMutableArray alloc] init];
                     if (@available(iOS 13.0, *)) {
@@ -155,31 +162,18 @@ double geoFenceTimerInterval = 1.0;
 + (NSDictionary *)findMatchingBeaconForRegion:(CLBeaconRegion *)beaconRegion {
     if (beaconRegion == nil || beacons.count == 0) return nil;
 
-    if (@available(iOS 13.0, *)) {
-        NSString *detectedUUID = beaconRegion.UUID.UUIDString;
-        [CPLog info:@"CleverPushLocation: findMatchingBeacon - detected uuid: %@, major: %@, minor: %@",
-         detectedUUID, beaconRegion.major, beaconRegion.minor];
+    NSString *regionIdentifier = beaconRegion.identifier;
+    [CPLog info:@"CleverPushLocation: findMatchingBeacon - identifier: %@", regionIdentifier];
 
-        for (NSDictionary *storedBeacon in beacons) {
-            NSString *storedUUID  = [storedBeacon objectForKey:@"uuid"];
-            NSNumber *storedMajor = [storedBeacon objectForKey:@"major"];
-            NSNumber *storedMinor = [storedBeacon objectForKey:@"minor"];
-
-            BOOL uuidMatch  = [storedUUID caseInsensitiveCompare:detectedUUID] == NSOrderedSame;
-            BOOL majorMatch = storedMajor ? ([storedMajor unsignedShortValue] == [beaconRegion.major unsignedShortValue]) : YES;
-            BOOL minorMatch = storedMinor ? ([storedMinor unsignedShortValue] == [beaconRegion.minor unsignedShortValue]) : YES;
-
-            [CPLog info:@"CleverPushLocation: Comparing - storedUUID: %@, uuidMatch: %d, majorMatch: %d, minorMatch: %d",
-             storedUUID, uuidMatch, majorMatch, minorMatch];
-
-            if (uuidMatch && majorMatch && minorMatch) {
-                [CPLog info:@"CleverPushLocation: Beacon matched - %@", [storedBeacon objectForKey:@"_id"]];
-                return storedBeacon;
-            }
+    for (NSDictionary *storedBeacon in beacons) {
+        NSString *beaconId = [storedBeacon valueForKey:@"_id"];
+        if ([beaconId isEqualToString:regionIdentifier]) {
+            [CPLog info:@"CleverPushLocation: Beacon matched - %@", beaconId];
+            return storedBeacon;
         }
-
-        [CPLog info:@"CleverPushLocation: No matching beacon found for uuid: %@", detectedUUID];
     }
+
+    [CPLog info:@"CleverPushLocation: No matching beacon found for identifier: %@", regionIdentifier];
     return nil;
 }
 
@@ -193,10 +187,11 @@ double geoFenceTimerInterval = 1.0;
 }
 
 + (void)locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region {
-    [CPLog info:@"LocationManager: LocationManager didDetermineState %@", [region identifier]];
+    [CPLog info:@"LocationManager: didDetermineState %@ - %@",
+     [region identifier], state == CLRegionStateInside ? @"Inside" : @"Outside"];
     if (state == CLRegionStateInside) {
         [self locationManager:manager didEnterRegion:region];
-    }  else if (state == CLRegionStateOutside) {
+    } else if (state == CLRegionStateOutside && ![region isKindOfClass:[CLBeaconRegion class]]) {
         [self locationManager:manager didExitRegion:region];
     }
 }
@@ -229,13 +224,10 @@ double geoFenceTimerInterval = 1.0;
 
 + (void)locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region {
     if ([region isKindOfClass:[CLBeaconRegion class]]) {
-        CLBeaconRegion *beaconRegion = (CLBeaconRegion *)region;
         if (@available(iOS 13.0, *)) {
-            [CPLog info:@"LocationManager: Exited Beacon region - uuid: %@", beaconRegion.UUID.UUIDString];
-            NSDictionary *matchedBeacon = [self findMatchingBeaconForRegion:beaconRegion];
-            if (matchedBeacon) {
-                [self trackBeaconEvent:matchedBeacon];
-            }
+            CLBeaconRegion *beaconRegion = (CLBeaconRegion *)region;
+            [CPLog info:@"LocationManager: Exited Beacon region - identifier: %@, uuid: %@",
+             beaconRegion.identifier, beaconRegion.UUID.UUIDString];
         }
     } else {
         [CPLog info:@"LocationManager: Exited Geo Fence %@", [region identifier]];

--- a/CleverPushLocation/Source/CleverPushLocation.m
+++ b/CleverPushLocation/Source/CleverPushLocation.m
@@ -56,7 +56,27 @@ double geoFenceTimerInterval = 1.0;
                             }
                         }
                     }
-                    
+                });
+            }];
+        }];
+    });
+}
+
+#pragma mark - Beacon monitoring
+
++ (void)initBeacons {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^(void) {
+        [CleverPush getSubscriptionId:^(NSString* subscriptionId) {
+            if (subscriptionId == nil) {
+                [CPLog debug:@"CleverPushLocation: initBeacons: There is no subscription for CleverPush SDK."];
+            }
+            [CleverPush getChannelConfig:^(NSDictionary* channelConfig) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (!locationManager) {
+                        locationManager = [CLLocationManager new];
+                    }
+                    locationManager.delegate = (id)self;
+
                     for (CLRegion *monitoredRegion in locationManager.monitoredRegions) {
                         if ([monitoredRegion isKindOfClass:[CLBeaconRegion class]]) {
                             [locationManager stopMonitoringForRegion:monitoredRegion];
@@ -93,8 +113,8 @@ double geoFenceTimerInterval = 1.0;
                                 if (region == nil) continue;
 
                                 region.notifyOnEntry = YES;
-                                region.notifyOnExit = YES;
-                                region.notifyEntryStateOnDisplay = YES;
+                                region.notifyOnExit = NO;
+                                region.notifyEntryStateOnDisplay = NO;
 
                                 [beacons addObject:beacon];
                                 [locationManager startMonitoringForRegion:region];
@@ -189,7 +209,7 @@ double geoFenceTimerInterval = 1.0;
 + (void)locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region {
     [CPLog info:@"LocationManager: didDetermineState %@ - %@",
      [region identifier], state == CLRegionStateInside ? @"Inside" : @"Outside"];
-    if (state == CLRegionStateInside) {
+    if (state == CLRegionStateInside && ![region isKindOfClass:[CLBeaconRegion class]]) {
         [self locationManager:manager didEnterRegion:region];
     } else if (state == CLRegionStateOutside && ![region isKindOfClass:[CLBeaconRegion class]]) {
         [self locationManager:manager didExitRegion:region];
@@ -198,9 +218,10 @@ double geoFenceTimerInterval = 1.0;
 
 + (void)locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
     if ([region isKindOfClass:[CLBeaconRegion class]]) {
-        CLBeaconRegion *beaconRegion = (CLBeaconRegion *)region;
         if (@available(iOS 13.0, *)) {
-            [CPLog info:@"LocationManager: Entered Beacon region - uuid: %@", beaconRegion.UUID.UUIDString];
+            CLBeaconRegion *beaconRegion = (CLBeaconRegion *)region;
+            [CPLog info:@"LocationManager: Entered Beacon region - identifier: %@, uuid: %@",
+             beaconRegion.identifier, beaconRegion.UUID.UUIDString];
             NSDictionary *matchedBeacon = [self findMatchingBeaconForRegion:beaconRegion];
             if (matchedBeacon) {
                 [self trackBeaconEvent:matchedBeacon];

--- a/CleverPushLocation/Source/CleverPushLocation.m
+++ b/CleverPushLocation/Source/CleverPushLocation.m
@@ -316,7 +316,7 @@ static BOOL beaconDebugScanAll = NO;
         }
     } else {
         [CPLog info:@"LocationManager: Entered Geo Fence %@", [region identifier]];
-        if (geoFenceTimeoutCompleted == false && [self geoFenceRegionHasDelay:region]) {
+        if ([self geoFenceRegionHasDelay:region]) {
             [geoFenceTimer invalidate];
             geoFenceTimerDelay = 0;
             geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval
@@ -345,7 +345,7 @@ static BOOL beaconDebugScanAll = NO;
         }
     } else {
         [CPLog info:@"LocationManager: Exited Geo Fence %@", [region identifier]];
-        if (geoFenceTimeoutCompleted == false && [self geoFenceRegionHasDelay:region]) {
+        if ([self geoFenceRegionHasDelay:region]) {
             [geoFenceTimer invalidate];
             geoFenceTimerDelay = 0;
             geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval

--- a/CleverPushLocation/Source/CleverPushLocation.m
+++ b/CleverPushLocation/Source/CleverPushLocation.m
@@ -9,6 +9,7 @@
 CLLocationManager* locationManager;
 NSTimer *geoFenceTimer;
 double geoFenceTimerDelay;
+bool geoFenceTimeoutCompleted;
 NSMutableArray *delayedGeoFences;
 NSMutableArray *beacons;
 NSString* geoFenceEnterState = @"enter";
@@ -19,8 +20,6 @@ static NSMutableDictionary *beaconLastFiredDate = nil;
 static CPBeaconDetectedHandler beaconDetectedHandler = nil;
 static NSTimeInterval beaconEventIntervalSec = 0;
 static BOOL beaconDebugScanAll = NO;
-static NSMutableSet *cleverPushGeoFenceIdentifiers = nil;
-static NSMutableSet *cleverPushBeaconIdentifiers = nil;
 
 #pragma mark - Geo-fence monitoring
 
@@ -37,22 +36,16 @@ static NSMutableSet *cleverPushBeaconIdentifiers = nil;
                     }
                     locationManager.delegate = (id)self;
                     
-                    if (!cleverPushGeoFenceIdentifiers) {
-                        cleverPushGeoFenceIdentifiers = [[NSMutableSet alloc] init];
+                    for (CLRegion *monitoredRegion in locationManager.monitoredRegions.allObjects) {
+                        if ([monitoredRegion isKindOfClass:[CLCircularRegion class]]) {
+                            [locationManager stopMonitoringForRegion:monitoredRegion];
+                            [CPLog info:@"CleverPushLocation: Stopped stale geo-fence region %@", monitoredRegion.identifier];
+                        }
                     }
-                    NSArray *staleGeoFenceRegions = [locationManager.monitoredRegions.allObjects filteredArrayUsingPredicate:
-                        [NSPredicate predicateWithBlock:^BOOL(id obj, NSDictionary *b) {
-                            return [obj isKindOfClass:[CLCircularRegion class]]
-                                && [cleverPushGeoFenceIdentifiers containsObject:[(CLRegion *)obj identifier]];
-                        }]];
-                    for (CLRegion *monitoredRegion in staleGeoFenceRegions) {
-                        [locationManager stopMonitoringForRegion:monitoredRegion];
-                        [CPLog info:@"CleverPushLocation: Stopped stale geo-fence region %@", monitoredRegion.identifier];
-                    }
-                    [cleverPushGeoFenceIdentifiers removeAllObjects];
 
                     [geoFenceTimer invalidate];
                     geoFenceTimerDelay = 0;
+                    geoFenceTimeoutCompleted = false;
                     [delayedGeoFences removeAllObjects];
                     delayedGeoFences = [[NSMutableArray alloc] init];
 
@@ -60,11 +53,10 @@ static NSMutableSet *cleverPushBeaconIdentifiers = nil;
                     if (channelConfig != nil && geoFencesDict != nil && [geoFencesDict count] > 0) {
                         for (NSDictionary *geoFence in geoFencesDict) {
                             if (geoFence != nil) {
-                                NSString *geoFenceId = [geoFence valueForKey:@"_id"];
                                 CLLocationCoordinate2D center = CLLocationCoordinate2DMake([[geoFence objectForKey:@"latitude"] doubleValue], [[geoFence objectForKey:@"longitude"] doubleValue]);
                                 CLRegion *region = [[CLCircularRegion alloc]initWithCenter:center
                                                                                     radius:[[geoFence objectForKey:@"radius"] longValue]
-                                                                                identifier:geoFenceId];
+                                                                                identifier:[geoFence valueForKey:@"_id"]];
                                 
                                 if ([geoFence objectForKey:@"delay"]) {
                                     double delayValue = [[geoFence objectForKey:@"delay"]doubleValue];
@@ -74,7 +66,6 @@ static NSMutableSet *cleverPushBeaconIdentifiers = nil;
                                                                     nil];
                                     [delayedGeoFences addObject:dataDic];
                                 }
-                                [cleverPushGeoFenceIdentifiers addObject:geoFenceId];
                                 [locationManager startMonitoringForRegion:region];
                             }
                         }
@@ -100,19 +91,12 @@ static NSMutableSet *cleverPushBeaconIdentifiers = nil;
                     }
                     locationManager.delegate = (id)self;
 
-                    if (!cleverPushBeaconIdentifiers) {
-                        cleverPushBeaconIdentifiers = [[NSMutableSet alloc] init];
+                    for (CLRegion *monitoredRegion in locationManager.monitoredRegions.allObjects) {
+                        if ([monitoredRegion isKindOfClass:[CLBeaconRegion class]]) {
+                            [locationManager stopMonitoringForRegion:monitoredRegion];
+                            [CPLog info:@"CleverPushLocation: Stopped stale beacon region %@", monitoredRegion.identifier];
+                        }
                     }
-                    NSArray *staleBeaconRegions = [locationManager.monitoredRegions.allObjects filteredArrayUsingPredicate:
-                        [NSPredicate predicateWithBlock:^BOOL(id obj, NSDictionary *b) {
-                            return [obj isKindOfClass:[CLBeaconRegion class]]
-                                && [cleverPushBeaconIdentifiers containsObject:[(CLRegion *)obj identifier]];
-                        }]];
-                    for (CLRegion *monitoredRegion in staleBeaconRegions) {
-                        [locationManager stopMonitoringForRegion:monitoredRegion];
-                        [CPLog info:@"CleverPushLocation: Stopped stale beacon region %@", monitoredRegion.identifier];
-                    }
-                    [cleverPushBeaconIdentifiers removeAllObjects];
 
                     beacons = [[NSMutableArray alloc] init];
                     beaconLastFiredDate = [[NSMutableDictionary alloc] init];
@@ -150,7 +134,6 @@ static NSMutableSet *cleverPushBeaconIdentifiers = nil;
                                 region.notifyEntryStateOnDisplay = NO;
 
                                 [beacons addObject:beacon];
-                                [cleverPushBeaconIdentifiers addObject:beaconId];
                                 [locationManager startMonitoringForRegion:region];
                                 [CPLog info:@"CleverPushLocation: Started monitoring beacon %@ (UUID: %@)", beaconId, uuidString];
                             }
@@ -214,6 +197,7 @@ static NSMutableSet *cleverPushBeaconIdentifiers = nil;
             if (delayedGeoFences.count == 0) {
                 [geoFenceTimer invalidate];
                 geoFenceTimerDelay = 0;
+                geoFenceTimeoutCompleted = false;
             }
         } onFailure:nil];
     });
@@ -249,10 +233,9 @@ static NSMutableSet *cleverPushBeaconIdentifiers = nil;
     [CPLog info:@"CleverPushLocation: trackBeaconEvent - beaconId: %@, eventName: %@", beaconId, eventName];
     [CleverPush trackEvent:eventName];
 
-    CPBeaconDetectedHandler handler = beaconDetectedHandler;
-    if (handler) {
+    if (beaconDetectedHandler) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            handler(beacon);
+            beaconDetectedHandler(beacon);
         });
     }
 }
@@ -277,16 +260,6 @@ static NSMutableSet *cleverPushBeaconIdentifiers = nil;
         [CPLog info:@"[BeaconDebug] No config match for identifier: %@", regionIdentifier];
     }
     return nil;
-}
-
-+ (BOOL)geoFenceRegionHasDelay:(CLRegion *)region {
-    for (NSDictionary *geoFence in delayedGeoFences) {
-        CLRegion *r = [geoFence objectForKey:@"region"];
-        if ([[r identifier] isEqualToString:[region identifier]]) {
-            return YES;
-        }
-    }
-    return NO;
 }
 
 #pragma mark - Location delegates
@@ -334,13 +307,7 @@ static NSMutableSet *cleverPushBeaconIdentifiers = nil;
         }
     } else {
         [CPLog info:@"LocationManager: Entered Geo Fence %@", [region identifier]];
-        if ([self geoFenceRegionHasDelay:region]) {
-            for (NSMutableDictionary *gf in delayedGeoFences) {
-                if ([[[gf objectForKey:@"region"] identifier] isEqualToString:[region identifier]]) {
-                    [gf setObject:geoFenceEnterState forKey:@"pendingState"];
-                    break;
-                }
-            }
+        if (geoFenceTimeoutCompleted == false) {
             [geoFenceTimer invalidate];
             geoFenceTimerDelay = 0;
             geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval
@@ -369,13 +336,7 @@ static NSMutableSet *cleverPushBeaconIdentifiers = nil;
         }
     } else {
         [CPLog info:@"LocationManager: Exited Geo Fence %@", [region identifier]];
-        if ([self geoFenceRegionHasDelay:region]) {
-            for (NSMutableDictionary *gf in delayedGeoFences) {
-                if ([[[gf objectForKey:@"region"] identifier] isEqualToString:[region identifier]]) {
-                    [gf setObject:geoFenceExitState forKey:@"pendingState"];
-                    break;
-                }
-            }
+        if (geoFenceTimeoutCompleted == false) {
             [geoFenceTimer invalidate];
             geoFenceTimerDelay = 0;
             geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval
@@ -394,26 +355,16 @@ static NSMutableSet *cleverPushBeaconIdentifiers = nil;
 }
 
 + (void)geoFenceHandleTimer:(NSTimer *)timer {
-    NSMutableDictionary *expiredGeoFence = nil;
-    CLRegion *expiredRegion = nil;
-    NSString *pendingState = nil;
     for (NSMutableDictionary *geoFence in delayedGeoFences) {
         if ([geoFence objectForKey:@"delay"] != nil) {
             double delayValue = [[geoFence objectForKey:@"delay"] doubleValue];
+            CLRegion *regionValue = [geoFence objectForKey:@"region"];
             if (geoFenceTimerDelay >= delayValue) {
-                expiredGeoFence = geoFence;
-                expiredRegion = [geoFence objectForKey:@"region"];
-                pendingState = [geoFence objectForKey:@"pendingState"];
+                geoFenceTimeoutCompleted = true;
+                [delayedGeoFences removeObject:geoFence];
+                [locationManager startMonitoringForRegion:regionValue];
                 break;
             }
-        }
-    }
-    if (expiredGeoFence) {
-        [delayedGeoFences removeObject:expiredGeoFence];
-        if (pendingState) {
-            [self trackGeoFence:[expiredRegion identifier] withState:pendingState];
-        } else {
-            [CPLog error:@"CleverPushLocation: geoFenceHandleTimer - no pendingState recorded for %@", [expiredRegion identifier]];
         }
     }
     geoFenceTimerDelay += 1;

--- a/CleverPushLocation/Source/CleverPushLocation.m
+++ b/CleverPushLocation/Source/CleverPushLocation.m
@@ -9,7 +9,6 @@
 CLLocationManager* locationManager;
 NSTimer *geoFenceTimer;
 double geoFenceTimerDelay;
-bool geoFenceTimeoutCompleted;
 NSMutableArray *delayedGeoFences;
 NSMutableArray *beacons;
 NSString* geoFenceEnterState = @"enter";
@@ -20,6 +19,8 @@ static NSMutableDictionary *beaconLastFiredDate = nil;
 static CPBeaconDetectedHandler beaconDetectedHandler = nil;
 static NSTimeInterval beaconEventIntervalSec = 0;
 static BOOL beaconDebugScanAll = NO;
+static NSMutableSet *cleverPushGeoFenceIdentifiers = nil;
+static NSMutableSet *cleverPushBeaconIdentifiers = nil;
 
 #pragma mark - Geo-fence monitoring
 
@@ -36,29 +37,34 @@ static BOOL beaconDebugScanAll = NO;
                     }
                     locationManager.delegate = (id)self;
                     
+                    if (!cleverPushGeoFenceIdentifiers) {
+                        cleverPushGeoFenceIdentifiers = [[NSMutableSet alloc] init];
+                    }
                     NSArray *staleGeoFenceRegions = [locationManager.monitoredRegions.allObjects filteredArrayUsingPredicate:
                         [NSPredicate predicateWithBlock:^BOOL(id obj, NSDictionary *b) {
-                            return [obj isKindOfClass:[CLCircularRegion class]];
+                            return [obj isKindOfClass:[CLCircularRegion class]]
+                                && [cleverPushGeoFenceIdentifiers containsObject:[(CLRegion *)obj identifier]];
                         }]];
                     for (CLRegion *monitoredRegion in staleGeoFenceRegions) {
                         [locationManager stopMonitoringForRegion:monitoredRegion];
                         [CPLog info:@"CleverPushLocation: Stopped stale geo-fence region %@", monitoredRegion.identifier];
                     }
+                    [cleverPushGeoFenceIdentifiers removeAllObjects];
+
+                    [geoFenceTimer invalidate];
+                    geoFenceTimerDelay = 0;
+                    [delayedGeoFences removeAllObjects];
+                    delayedGeoFences = [[NSMutableArray alloc] init];
 
                     NSArray* geoFencesDict = [channelConfig cleverPushArrayForKey:@"geoFences"];
                     if (channelConfig != nil && geoFencesDict != nil && [geoFencesDict count] > 0) {
-                        [geoFenceTimer invalidate];
-                        geoFenceTimerDelay = 0;
-                        geoFenceTimeoutCompleted = false;
-                        [delayedGeoFences removeAllObjects];
-                        delayedGeoFences = [[NSMutableArray alloc] init];
-                        
                         for (NSDictionary *geoFence in geoFencesDict) {
                             if (geoFence != nil) {
+                                NSString *geoFenceId = [geoFence valueForKey:@"_id"];
                                 CLLocationCoordinate2D center = CLLocationCoordinate2DMake([[geoFence objectForKey:@"latitude"] doubleValue], [[geoFence objectForKey:@"longitude"] doubleValue]);
                                 CLRegion *region = [[CLCircularRegion alloc]initWithCenter:center
                                                                                     radius:[[geoFence objectForKey:@"radius"] longValue]
-                                                                                identifier:[geoFence valueForKey:@"_id"]];
+                                                                                identifier:geoFenceId];
                                 
                                 if ([geoFence objectForKey:@"delay"]) {
                                     double delayValue = [[geoFence objectForKey:@"delay"]doubleValue];
@@ -68,6 +74,7 @@ static BOOL beaconDebugScanAll = NO;
                                                                     nil];
                                     [delayedGeoFences addObject:dataDic];
                                 }
+                                [cleverPushGeoFenceIdentifiers addObject:geoFenceId];
                                 [locationManager startMonitoringForRegion:region];
                             }
                         }
@@ -93,14 +100,19 @@ static BOOL beaconDebugScanAll = NO;
                     }
                     locationManager.delegate = (id)self;
 
+                    if (!cleverPushBeaconIdentifiers) {
+                        cleverPushBeaconIdentifiers = [[NSMutableSet alloc] init];
+                    }
                     NSArray *staleBeaconRegions = [locationManager.monitoredRegions.allObjects filteredArrayUsingPredicate:
                         [NSPredicate predicateWithBlock:^BOOL(id obj, NSDictionary *b) {
-                            return [obj isKindOfClass:[CLBeaconRegion class]];
+                            return [obj isKindOfClass:[CLBeaconRegion class]]
+                                && [cleverPushBeaconIdentifiers containsObject:[(CLRegion *)obj identifier]];
                         }]];
                     for (CLRegion *monitoredRegion in staleBeaconRegions) {
                         [locationManager stopMonitoringForRegion:monitoredRegion];
                         [CPLog info:@"CleverPushLocation: Stopped stale beacon region %@", monitoredRegion.identifier];
                     }
+                    [cleverPushBeaconIdentifiers removeAllObjects];
 
                     beacons = [[NSMutableArray alloc] init];
                     beaconLastFiredDate = [[NSMutableDictionary alloc] init];
@@ -138,6 +150,7 @@ static BOOL beaconDebugScanAll = NO;
                                 region.notifyEntryStateOnDisplay = NO;
 
                                 [beacons addObject:beacon];
+                                [cleverPushBeaconIdentifiers addObject:beaconId];
                                 [locationManager startMonitoringForRegion:region];
                                 [CPLog info:@"CleverPushLocation: Started monitoring beacon %@ (UUID: %@)", beaconId, uuidString];
                             }
@@ -201,7 +214,6 @@ static BOOL beaconDebugScanAll = NO;
             if (delayedGeoFences.count == 0) {
                 [geoFenceTimer invalidate];
                 geoFenceTimerDelay = 0;
-                geoFenceTimeoutCompleted = false;
             }
         } onFailure:nil];
     });
@@ -323,6 +335,12 @@ static BOOL beaconDebugScanAll = NO;
     } else {
         [CPLog info:@"LocationManager: Entered Geo Fence %@", [region identifier]];
         if ([self geoFenceRegionHasDelay:region]) {
+            for (NSMutableDictionary *gf in delayedGeoFences) {
+                if ([[[gf objectForKey:@"region"] identifier] isEqualToString:[region identifier]]) {
+                    [gf setObject:geoFenceEnterState forKey:@"pendingState"];
+                    break;
+                }
+            }
             [geoFenceTimer invalidate];
             geoFenceTimerDelay = 0;
             geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval
@@ -352,6 +370,12 @@ static BOOL beaconDebugScanAll = NO;
     } else {
         [CPLog info:@"LocationManager: Exited Geo Fence %@", [region identifier]];
         if ([self geoFenceRegionHasDelay:region]) {
+            for (NSMutableDictionary *gf in delayedGeoFences) {
+                if ([[[gf objectForKey:@"region"] identifier] isEqualToString:[region identifier]]) {
+                    [gf setObject:geoFenceExitState forKey:@"pendingState"];
+                    break;
+                }
+            }
             [geoFenceTimer invalidate];
             geoFenceTimerDelay = 0;
             geoFenceTimer = [NSTimer scheduledTimerWithTimeInterval:geoFenceTimerInterval
@@ -372,20 +396,25 @@ static BOOL beaconDebugScanAll = NO;
 + (void)geoFenceHandleTimer:(NSTimer *)timer {
     NSMutableDictionary *expiredGeoFence = nil;
     CLRegion *expiredRegion = nil;
+    NSString *pendingState = nil;
     for (NSMutableDictionary *geoFence in delayedGeoFences) {
         if ([geoFence objectForKey:@"delay"] != nil) {
             double delayValue = [[geoFence objectForKey:@"delay"] doubleValue];
             if (geoFenceTimerDelay >= delayValue) {
-                geoFenceTimeoutCompleted = true;
                 expiredGeoFence = geoFence;
                 expiredRegion = [geoFence objectForKey:@"region"];
+                pendingState = [geoFence objectForKey:@"pendingState"];
                 break;
             }
         }
     }
     if (expiredGeoFence) {
         [delayedGeoFences removeObject:expiredGeoFence];
-        [locationManager startMonitoringForRegion:expiredRegion];
+        if (pendingState) {
+            [self trackGeoFence:[expiredRegion identifier] withState:pendingState];
+        } else {
+            [CPLog error:@"CleverPushLocation: geoFenceHandleTimer - no pendingState recorded for %@", [expiredRegion identifier]];
+        }
     }
     geoFenceTimerDelay += 1;
 }


### PR DESCRIPTION
Added iBeacon monitoring support for cleverpush SDK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes location monitoring and event firing on device; geofence delay/monitoring behavior changed, which could alter production geo-fence analytics.
> 
> **Overview**
> Adds **iBeacon monitoring** on iOS 13+ via a new `+initBeacons` path that reads channel `beacons`, tears down stale `CLBeaconRegion`s, and registers entry-only regions (UUID with optional major/minor). On beacon entry it matches config by region `_id`, calls `+trackBeaconEvent:` to fire `eventName` through `CleverPush trackEvent`, and optionally invokes an `+onBeaconDetected` callback. **Throttling** is configurable with `+setBeaconEventInterval:`; **debug** logging uses `+setBeaconDebugScanAll:`. Beacon regions are excluded from `didDetermineState` enter/exit forwarding to avoid duplicate events.
> 
> **Geofence `+init`** is refactored to always set up a shared `CLLocationManager`, clear stale circular regions, and **start monitoring every fence immediately** (delay only gates tracking via the existing timer, not whether monitoring starts). Exposes `+hasLocationPermission`, adds `monitoringDidFailForRegion:` logging, and routes beacon vs circular regions separately in enter/exit delegates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 967be9965926358bf877cd984bbc9d89434deb5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements CP-11478: Adds iBeacon monitoring on iOS 13+ with entry-triggered event tracking, throttling, and an optional detection callback. Splits beacon vs. geofence init, cleans up stale monitored regions, and prevents duplicate enter events.

- **New Features**
  - Beacons: `+initBeacons` registers `CLBeaconRegion`s from channel beacons, clears stale beacon regions, entry-only; matches by beacon `_id` (region identifier). On entry calls `+trackBeaconEvent:` (fires `eventName`) and optional `+onBeaconDetected`. Adds `+setBeaconEventInterval` (throttle) and `+setBeaconDebugScanAll` (verbose logs incl. `didDetermineState`). Skips `didDetermineState` forwarding to avoid duplicates. Requires iOS 13+.
  - Geofences & permissions: `+init` shares one `CLLocationManager`, removes stale `CLCircularRegion`s, and starts monitoring all fences immediately; delay now only gates tracking via a per-fence timer. Adds `monitoringDidFailForRegion:` logging, exposes `+hasLocationPermission`, and fixes delayed-timer cleanup/state.

<sup>Written for commit 967be9965926358bf877cd984bbc9d89434deb5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

