### PR TITLE
feature/cp-11869-ios-in-app-banner-test-bypassconditions-support

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.h
+++ b/CleverPush/Source/CPAppBannerModuleInstance.h
@@ -108,6 +108,7 @@
 + (NSMutableArray*)getBannersForDeepLink;
 + (void)updateBannersForDeepLinkWithURL:(NSURL*)url;
 + (void)addSilentPushAppBannersId:(NSString*)appBannerId notificationId:(NSString*)notificationId;
++ (void)addSilentPushAppBannersId:(NSString*)appBannerId notificationId:(NSString*)notificationId bypassConditions:(BOOL)bypassConditions;
 + (void)setAppBannerPerDayValue:(int)dayValue;
 + (void)setAppBannerPerEachSessionValue:(int)sessionValue;
 + (int)getAppBannerPerDayValue;

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -2205,9 +2205,13 @@ int appBannerPerDayValue = 0;
     NSArray *filteredArray = [existingArray filteredArrayUsingPredicate:predicate];
 
     if (filteredArray != nil && filteredArray.count > 0) {
-        NSMutableDictionary *existingDict = [filteredArray.firstObject mutableCopy];
-        existingDict[@"appBanner"] = appBannerId;
-        existingDict[@"bypassConditions"] = @(bypassConditions);
+        NSUInteger index = [existingArray indexOfObject:filteredArray.firstObject];
+        if (index != NSNotFound) {
+            NSMutableDictionary *existingDict = [filteredArray.firstObject mutableCopy];
+            existingDict[@"appBanner"] = appBannerId;
+            existingDict[@"bypassConditions"] = @(bypassConditions);
+            [existingArray replaceObjectAtIndex:index withObject:existingDict];
+        }
     } else {
         if (notificationId != nil && appBannerId != nil) {
             [existingArray addObject:@{

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -140,7 +140,7 @@ int appBannerPerDayValue = 0;
                     break;
                 }
                 if (![CPUtils isNullOrEmpty:notificationId]) {
-                    if (banner.triggers.count > 0) {
+                    if (!force && banner.triggers.count > 0) {
                         [self validatePushBannerTrigger:banner force:force notificationId:notificationId];
                     } else {
                         [self showBanner:banner force:force notificationId:notificationId];
@@ -2185,14 +2185,17 @@ int appBannerPerDayValue = 0;
 
 #pragma mark - set app banner ids from silent push
 + (void)addSilentPushAppBannersId:(NSString *)appBannerId notificationId:(NSString *)notificationId {
+    [self addSilentPushAppBannersId:appBannerId notificationId:notificationId bypassConditions:NO];
+}
+
++ (void)addSilentPushAppBannersId:(NSString *)appBannerId notificationId:(NSString *)notificationId bypassConditions:(BOOL)bypassConditions {
     if ([CPUtils isNullOrEmpty:appBannerId] || [CPUtils isNullOrEmpty:notificationId]) {
         [CPLog debug:@"CPAppBannerModuleInstance: addSilentPushAppBannersId: appBannerId or notification ID is blank, null, or empty."];
         return;
     }
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSMutableArray *existingArray = [[NSMutableArray alloc] init];
-    existingArray = [[defaults objectForKey:CLEVERPUSH_SILENT_PUSH_APP_BANNERS_KEY] mutableCopy];
+    NSMutableArray *existingArray = [[defaults objectForKey:CLEVERPUSH_SILENT_PUSH_APP_BANNERS_KEY] mutableCopy];
 
     if (!existingArray) {
         existingArray = [[NSMutableArray alloc] init];
@@ -2204,9 +2207,14 @@ int appBannerPerDayValue = 0;
     if (filteredArray != nil && filteredArray.count > 0) {
         NSMutableDictionary *existingDict = [filteredArray.firstObject mutableCopy];
         existingDict[@"appBanner"] = appBannerId;
+        existingDict[@"bypassConditions"] = @(bypassConditions);
     } else {
         if (notificationId != nil && appBannerId != nil) {
-            [existingArray addObject:@{ @"notificationId": notificationId, @"appBanner": appBannerId }];
+            [existingArray addObject:@{
+                @"notificationId": notificationId,
+                @"appBanner": appBannerId,
+                @"bypassConditions": @(bypassConditions)
+            }];
         }
     }
 
@@ -2227,7 +2235,8 @@ int appBannerPerDayValue = 0;
         }
         NSMutableArray *objectsToRemove = [[NSMutableArray alloc] init];
         for (NSMutableDictionary *eventsObject in appBanners) {
-            [self showBanner:channelId bannerId:[eventsObject objectForKey:@"appBanner"] notificationId:[eventsObject objectForKey:@"notificationId"] force:NO];
+            BOOL storedBypassConditions = [[eventsObject objectForKey:@"bypassConditions"] boolValue];
+            [self showBanner:channelId bannerId:[eventsObject objectForKey:@"appBanner"] notificationId:[eventsObject objectForKey:@"notificationId"] force:storedBypassConditions];
             [objectsToRemove addObject:eventsObject];
         }
         [appBanners removeObjectsInArray:objectsToRemove];

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -2109,7 +2109,9 @@ static id isNil(id object) {
             [CPAppBannerModuleInstance setCurrentVoucherCodePlaceholder:voucherCodesByAppBanner];
         }
 
-        [self showAppBanner:[notification valueForKey:@"appBanner"] channelId:[payloadMutable cleverPushStringForKeyPath:@"channel._id"] notificationId:notificationId];
+        id bypassValue = [notification objectForKey:@"bypassConditions"];
+        BOOL bypassConditions = bypassValue != nil && ![bypassValue isKindOfClass:[NSNull class]] && [bypassValue boolValue];
+        [self showAppBanner:[notification valueForKey:@"appBanner"] channelId:[payloadMutable cleverPushStringForKeyPath:@"channel._id"] notificationId:notificationId force:bypassConditions];
     }
 
     payloadMutable = [self handleActionInNotification:notification withAction:action payloadMutable:payloadMutable];
@@ -2156,13 +2158,15 @@ static id isNil(id object) {
 
     NSString* appBanner = [notification cleverPushStringForKey:@"appBanner"];
     bool isSilent = [notification objectForKey:@"silent"] != nil && ![[notification objectForKey:@"silent"] isKindOfClass:[NSNull class]] && [[notification objectForKey:@"silent"] boolValue];
-
+    id bypassValue = [notification objectForKey:@"bypassConditions"];
+    BOOL bypassConditions = bypassValue != nil && ![bypassValue isKindOfClass:[NSNull class]] && [bypassValue boolValue];
+    
     if (![CPUtils isNullOrEmpty:appBanner] && isSilent) {
       BOOL isActive = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
       if (isActive) {
-        [self showAppBanner:appBanner channelId:[messageDict cleverPushStringForKeyPath:@"channel._id"] notificationId:notificationId];
+        [self showAppBanner:appBanner channelId:[messageDict cleverPushStringForKeyPath:@"channel._id"] notificationId:notificationId force:bypassConditions];
       } else {
-        [CPAppBannerModuleInstance addSilentPushAppBannersId:appBanner notificationId:notificationId];
+        [CPAppBannerModuleInstance addSilentPushAppBannersId:appBanner notificationId:notificationId bypassConditions:bypassConditions];
       }
     }
 }
@@ -4660,6 +4664,12 @@ static id isNil(id object) {
     BOOL fromNotification = notificationId != nil;
     [CPAppBannerModule initBannersWithChannel:channelId showDrafts:isShowDraft fromNotification:fromNotification];
     [CPAppBannerModule showBanner:channelId bannerId:bannerId notificationId:notificationId force:NO appBannerClosedCallback:appBannerClosedCallback];
+}
+
+- (void)showAppBanner:(NSString*)bannerId channelId:(NSString*)channelId notificationId:(NSString*)notificationId force:(BOOL)force {
+    BOOL fromNotification = notificationId != nil;
+    [CPAppBannerModule initBannersWithChannel:channelId showDrafts:isShowDraft fromNotification:fromNotification];
+    [CPAppBannerModule showBanner:channelId bannerId:bannerId notificationId:notificationId force:force appBannerClosedCallback:nil];
 }
 
 - (void)setAppBannerOpenedCallback:(CPAppBannerActionBlock _Nullable)callback {


### PR DESCRIPTION
Add support for bypassConditions on banners attached to push notifications. When a push notification has an attached banner and bypassConditions is true, the banner's targeting conditions are skipped so the banner is shown directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how in-app banners display from pushes, including bypassing targeting and frequency guards when force is set; behavior is payload-driven but affects core messaging UX.
> 
> **Overview**
> Push notifications can carry **`bypassConditions`** on an attached app banner. When it is true, the SDK maps that to the existing **`force`** path so push-triggered banners skip trigger validation and the usual targeting/frequency/session limits inside `showBanner`.
> 
> **`CleverPushInstance`** reads `bypassConditions` from the notification for both opened and silent pushes and calls the new **`showAppBanner:channelId:notificationId:force:`** overload. Silent pushes that arrive while the app is inactive persist **`bypassConditions`** in `NSUserDefaults` via **`addSilentPushAppBannersId:notificationId:bypassConditions:`** and apply it when **`showPendingSilentPushAppBannersIds`** runs later.
> 
> For notification-backed shows, **`validatePushBannerTrigger`** is only used when **`force`** is false and the banner has triggers. Updating an existing silent-push queue entry now replaces the stored dictionary (including `bypassConditions`) instead of mutating without writing back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a49a768e9238cda034d9e2d0e74568170d31df6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for bypassing banner targeting for push-attached banners when bypassConditions is true, so the banner shows immediately. Works for both opened and silent notifications.

- **New Features**
  - Reads bypassConditions from the notification payload and forwards it as force to skip trigger validation when showing the banner.
  - Persists bypassConditions with appBanner for silent pushes and applies it when processed later.
  - New APIs: `addSilentPushAppBannersId:notificationId:bypassConditions:` and `showAppBanner:channelId:notificationId:force:`; existing methods remain unchanged.

<sup>Written for commit a49a768e9238cda034d9e2d0e74568170d31df6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

