### PR TITLE
hotfix/cp-12061-ios-trips-app-in-app-banner-is-displayed-incorrectly-after

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -31,6 +31,7 @@ CPAppBannerClosedBlock handleBannerClosed;
 CPSQLiteManager *sqlManager;
 CPAppBannerDisplayBlock handleBannerDisplayed;
 CPAppBannerPassthroughView *activeBannerOverlay;
+CPAppBannerViewController *activeNonBlockingBannerController;
 
 static NSObject *callbackLock;
 static NSObject *bannerRequestLock;
@@ -1820,7 +1821,8 @@ int appBannerPerDayValue = 0;
 
     [overlayHostView addSubview:overlay];
     activeBannerOverlay = overlay;
-    
+    activeNonBlockingBannerController = appBannerViewController;
+
     __weak CPAppBannerPassthroughView *weakOverlay = overlay;
     __weak CPAppBannerViewController *weakBannerVC = appBannerViewController;
 
@@ -1860,6 +1862,7 @@ int appBannerPerDayValue = 0;
             [weakBannerVC removeFromParentViewController];
         }
         activeBannerOverlay = nil;
+        activeNonBlockingBannerController = nil;
     };
 
     if (banner.stopAtType == CPAppBannerStopAtTypeRelativeToDelivery) {

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -1791,14 +1791,21 @@ int appBannerPerDayValue = 0;
     }
     
     UIViewController *hostVC = [CleverPush topViewController];
+    BOOL alertOnTop = NO;
     while ([hostVC isKindOfClass:[UIAlertController class]] && hostVC.presentingViewController) {
+        alertOnTop = YES;
         hostVC = hostVC.presentingViewController;
     }
     if (!hostVC) {
         return;
     }
 
-    CPAppBannerPassthroughView *overlay = [[CPAppBannerPassthroughView alloc] initWithFrame:hostVC.view.bounds];
+    UIView *overlayHostView = hostVC.view;
+    if (alertOnTop && hostVC.view.window != nil) {
+        overlayHostView = hostVC.view.window;
+    }
+
+    CPAppBannerPassthroughView *overlay = [[CPAppBannerPassthroughView alloc] initWithFrame:overlayHostView.bounds];
     overlay.backgroundColor = [UIColor clearColor];
     overlay.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
@@ -1809,7 +1816,7 @@ int appBannerPerDayValue = 0;
     [overlay addSubview:appBannerViewController.view];
     [appBannerViewController didMoveToParentViewController:hostVC];
 
-    [hostVC.view addSubview:overlay];
+    [overlayHostView addSubview:overlay];
     activeBannerOverlay = overlay;
 
     __weak CPAppBannerPassthroughView *weakOverlay = overlay;
@@ -1866,12 +1873,7 @@ int appBannerPerDayValue = 0;
         return;
     }
 
-    UIModalPresentationStyle presentationStyle = [CleverPush getAppBannerModalPresentationStyle];
-    if ([topController isKindOfClass:[UIAlertController class]]
-        && (presentationStyle == UIModalPresentationOverCurrentContext || presentationStyle == UIModalPresentationCurrentContext)) {
-        presentationStyle = UIModalPresentationOverFullScreen;
-    }
-    [appBannerViewController setModalPresentationStyle:presentationStyle];
+    [appBannerViewController setModalPresentationStyle:[CPUtils appBannerPresentationStyleForPresenter:topController]];
     [appBannerViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
     appBannerViewController.view.alpha = 0.0;
     [topController presentViewController:appBannerViewController animated:NO completion:^{

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -1791,6 +1791,9 @@ int appBannerPerDayValue = 0;
     }
     
     UIViewController *hostVC = [CleverPush topViewController];
+    while ([hostVC isKindOfClass:[UIAlertController class]] && hostVC.presentingViewController) {
+        hostVC = hostVC.presentingViewController;
+    }
     if (!hostVC) {
         return;
     }
@@ -1853,9 +1856,6 @@ int appBannerPerDayValue = 0;
 
 #pragma mark - Blocking banner presentation (default modal)
 - (void)presentBlockingBanner:(CPAppBannerViewController*)appBannerViewController banner:(CPAppBanner*)banner notificationId:(NSString*)notificationId force:(BOOL)force {
-    [appBannerViewController setModalPresentationStyle:[CleverPush getAppBannerModalPresentationStyle]];
-    [appBannerViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
-
     if (!force && [CPUtils isNullOrEmpty:notificationId]) {
         [self incrementSessionBannerCount];
         [self incrementDailyBannerCount];
@@ -1865,6 +1865,14 @@ int appBannerPerDayValue = 0;
     if (!topController) {
         return;
     }
+
+    UIModalPresentationStyle presentationStyle = [CleverPush getAppBannerModalPresentationStyle];
+    if ([topController isKindOfClass:[UIAlertController class]]
+        && (presentationStyle == UIModalPresentationOverCurrentContext || presentationStyle == UIModalPresentationCurrentContext)) {
+        presentationStyle = UIModalPresentationOverFullScreen;
+    }
+    [appBannerViewController setModalPresentationStyle:presentationStyle];
+    [appBannerViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
     appBannerViewController.view.alpha = 0.0;
     [topController presentViewController:appBannerViewController animated:NO completion:^{
         [appBannerViewController finishSetup];

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -31,6 +31,7 @@ CPAppBannerClosedBlock handleBannerClosed;
 CPSQLiteManager *sqlManager;
 CPAppBannerDisplayBlock handleBannerDisplayed;
 CPAppBannerPassthroughView *activeBannerOverlay;
+CPAppBannerViewController *activeNonBlockingBannerController;
 
 static NSObject *callbackLock;
 static NSObject *bannerRequestLock;
@@ -1800,24 +1801,27 @@ int appBannerPerDayValue = 0;
         return;
     }
 
-    UIView *overlayHostView = hostVC.view;
-    if (alertOnTop && hostVC.view.window != nil) {
-        overlayHostView = hostVC.view.window;
-    }
+    BOOL attachToWindow = (alertOnTop && hostVC.view.window != nil);
+    UIView *overlayHostView = attachToWindow ? hostVC.view.window : hostVC.view;
 
     CPAppBannerPassthroughView *overlay = [[CPAppBannerPassthroughView alloc] initWithFrame:overlayHostView.bounds];
     overlay.backgroundColor = [UIColor clearColor];
     overlay.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
-    [hostVC addChildViewController:appBannerViewController];
+    if (!attachToWindow) {
+        [hostVC addChildViewController:appBannerViewController];
+    }
     appBannerViewController.view.frame = overlay.bounds;
     appBannerViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     appBannerViewController.view.alpha = 0.0;
     [overlay addSubview:appBannerViewController.view];
-    [appBannerViewController didMoveToParentViewController:hostVC];
+    if (!attachToWindow) {
+        [appBannerViewController didMoveToParentViewController:hostVC];
+    }
 
     [overlayHostView addSubview:overlay];
     activeBannerOverlay = overlay;
+    activeNonBlockingBannerController = appBannerViewController;
 
     __weak CPAppBannerPassthroughView *weakOverlay = overlay;
     __weak CPAppBannerViewController *weakBannerVC = appBannerViewController;
@@ -1850,10 +1854,15 @@ int appBannerPerDayValue = 0;
     }];
 
     appBannerViewController.windowDismissBlock = ^{
-        [weakBannerVC willMoveToParentViewController:nil];
+        if (weakBannerVC.parentViewController != nil) {
+            [weakBannerVC willMoveToParentViewController:nil];
+        }
         [weakOverlay removeFromSuperview];
-        [weakBannerVC removeFromParentViewController];
+        if (weakBannerVC.parentViewController != nil) {
+            [weakBannerVC removeFromParentViewController];
+        }
         activeBannerOverlay = nil;
+        activeNonBlockingBannerController = nil;
     };
 
     if (banner.stopAtType == CPAppBannerStopAtTypeRelativeToDelivery) {

--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -31,7 +31,6 @@ CPAppBannerClosedBlock handleBannerClosed;
 CPSQLiteManager *sqlManager;
 CPAppBannerDisplayBlock handleBannerDisplayed;
 CPAppBannerPassthroughView *activeBannerOverlay;
-CPAppBannerViewController *activeNonBlockingBannerController;
 
 static NSObject *callbackLock;
 static NSObject *bannerRequestLock;
@@ -1821,8 +1820,7 @@ int appBannerPerDayValue = 0;
 
     [overlayHostView addSubview:overlay];
     activeBannerOverlay = overlay;
-    activeNonBlockingBannerController = appBannerViewController;
-
+    
     __weak CPAppBannerPassthroughView *weakOverlay = overlay;
     __weak CPAppBannerViewController *weakBannerVC = appBannerViewController;
 
@@ -1862,7 +1860,6 @@ int appBannerPerDayValue = 0;
             [weakBannerVC removeFromParentViewController];
         }
         activeBannerOverlay = nil;
-        activeNonBlockingBannerController = nil;
     };
 
     if (banner.stopAtType == CPAppBannerStopAtTypeRelativeToDelivery) {

--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -259,12 +259,7 @@ CPNotificationClickBlock handleClick;
 
     UIViewController* topController = [CleverPush topViewController];
 
-    UIModalPresentationStyle presentationStyle = [CleverPush getAppBannerModalPresentationStyle];
-    if ([topController isKindOfClass:[UIAlertController class]]
-        && (presentationStyle == UIModalPresentationOverCurrentContext || presentationStyle == UIModalPresentationCurrentContext)) {
-        presentationStyle = UIModalPresentationOverFullScreen;
-    }
-    [appBannerViewController setModalPresentationStyle:presentationStyle];
+    [appBannerViewController setModalPresentationStyle:[CPUtils appBannerPresentationStyleForPresenter:topController]];
     [appBannerViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
 
     [topController presentViewController:appBannerViewController animated:YES completion:nil];

--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -255,11 +255,18 @@ CPNotificationClickBlock handleClick;
 - (void)presentAppBanner:(CPInboxDetailView*)appBannerViewController  banner:(CPAppBanner*)banner {
     [[NSUserDefaults standardUserDefaults] setBool:true forKey:CLEVERPUSH_APP_BANNER_VISIBLE_KEY];
     [[NSUserDefaults standardUserDefaults] synchronize];
-    [appBannerViewController setModalPresentationStyle:[CleverPush getAppBannerModalPresentationStyle]];
-    [appBannerViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
     appBannerViewController.data = banner;
 
     UIViewController* topController = [CleverPush topViewController];
+
+    UIModalPresentationStyle presentationStyle = [CleverPush getAppBannerModalPresentationStyle];
+    if ([topController isKindOfClass:[UIAlertController class]]
+        && (presentationStyle == UIModalPresentationOverCurrentContext || presentationStyle == UIModalPresentationCurrentContext)) {
+        presentationStyle = UIModalPresentationOverFullScreen;
+    }
+    [appBannerViewController setModalPresentationStyle:presentationStyle];
+    [appBannerViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
+
     [topController presentViewController:appBannerViewController animated:YES completion:nil];
 
     if (banner.dismissType == CPAppBannerDismissTypeTimeout) {

--- a/CleverPush/Source/CPUtils.h
+++ b/CleverPush/Source/CPUtils.h
@@ -23,6 +23,7 @@
 + (void)openSafari:(NSURL*)URL;
 + (CGFloat)frameHeightWithoutSafeArea;
 + (void)openSafari:(NSURL*)URL dismissViewController:(UIViewController*)controller;
++ (UIModalPresentationStyle)appBannerPresentationStyleForPresenter:(UIViewController*)presenter;
 + (void)handleLinkBySystem:(NSString*)urlString;
 + (NSString*)deviceName;
 + (void)updateLastTimeAutomaticallyShowed;

--- a/CleverPush/Source/CPUtils.m
+++ b/CleverPush/Source/CPUtils.m
@@ -317,6 +317,16 @@ NSString * const localeIdentifier = @"en_US_POSIX";
     }];
 }
 
+#pragma mark - Resolve the app banner presentation style for a given presenter.
++ (UIModalPresentationStyle)appBannerPresentationStyleForPresenter:(UIViewController*)presenter {
+    UIModalPresentationStyle presentationStyle = [CleverPush getAppBannerModalPresentationStyle];
+    if ([presenter isKindOfClass:[UIAlertController class]]
+        && (presentationStyle == UIModalPresentationOverCurrentContext || presentationStyle == UIModalPresentationCurrentContext)) {
+        return UIModalPresentationOverFullScreen;
+    }
+    return presentationStyle;
+}
+
 #pragma mark -  get the device name based on their model names.
 + (NSString*)deviceName {
     struct utsname systemInfo;


### PR DESCRIPTION
Resolved the issue of broken app banner layout when presented while a UIAlertController is visible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core banner presentation and view hierarchy (window overlays, modal styles) with moderate regression risk across blocking, non-blocking, and inbox flows, but scope is limited to the alert-on-top edge case.
> 
> **Overview**
> Fixes **broken in-app banner layout** when a `UIAlertController` is the top view controller (CP-12061).
> 
> **Non-blocking banners** now walk up from an alert to its presenter, and when an alert is on top they can attach the passthrough overlay to the **window** instead of the alert’s view—skipping child view-controller wiring in that case. Dismiss cleanup only removes the banner from the parent when it was actually added as a child, and the active non-blocking controller is tracked for teardown.
> 
> **Blocking** and **inbox** modal banners pick presentation style via new **`CPUtils.appBannerPresentationStyleForPresenter:`**, which keeps the configured style except when the presenter is an alert and the style is `OverCurrentContext` or `CurrentContext`, in which case it uses **`OverFullScreen`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 692f7f98e292d46c4acd2d66ce1a9c3be8023c07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect iOS in‑app banner layout when an alert is visible (CP-12061). Non‑blocking banners now bypass alerts and attach to the window; blocking/inbox banners choose a safe modal style to avoid clipping.

- **Bug Fixes**
  - Non‑blocking banners: walk up from `UIAlertController` to its presenter; when an alert is on top and a window exists, attach the overlay to the window; skip VC containment in this path; guard teardown on dismiss; track the active controller for cleanup.
  - Blocking and Inbox banners: set modal style via `CPUtils.appBannerPresentationStyleForPresenter`; upgrade `OverCurrentContext`/`CurrentContext` to `OverFullScreen` when presenting from a `UIAlertController`; keep cross‑dissolve transition.

<sup>Written for commit 692f7f98e292d46c4acd2d66ce1a9c3be8023c07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

