### PR TITLE
hotfix/CP-12079 - fixing deadlock issue on in-app-banners

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -430,11 +430,12 @@ int appBannerPerDayValue = 0;
         NSMutableArray *jsonBanners = [[NSMutableArray alloc] init];
         BOOL useGroupId = groupId != nil && ![groupId isEqualToString:@""];
 
+        NSArray *rawBanners = [result cleverPushArrayForKey:@"banners"];
         if (useGroupId) {
             NSPredicate *predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[[NSPredicate predicateWithFormat:[NSString stringWithFormat:@"SELF contains '%@'", groupId]], [NSPredicate predicateWithFormat:[NSString stringWithFormat:@"SELF contains 'published'"]]]];
-            jsonBanners = [[[result objectForKey:@"banners"] filteredArrayUsingPredicate:predicate] mutableCopy];
+            jsonBanners = [[rawBanners filteredArrayUsingPredicate:predicate] mutableCopy];
         } else {
-            jsonBanners = [[result objectForKey:@"banners"] mutableCopy];
+            jsonBanners = [rawBanners mutableCopy];
         }
         
         if (jsonBanners != nil) {
@@ -482,6 +483,12 @@ int appBannerPerDayValue = 0;
                     pendingBannerListeners = [NSMutableArray new];
                 }
             }
+        } else {
+            @synchronized(bannerRequestLock) {
+                pendingBannerRequest = NO;
+                pendingBannerListeners = [NSMutableArray new];
+            }
+            [CPLog error:@"Failed getting app banners because the response did not contain a banners array"];
         }
     } onFailure:^(NSError* error) {
         @synchronized(bannerRequestLock) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9b5513e33788ef23abf5e5091bebc0a8f6036f87. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a deadlock that blocked in‑app banner loading for the entire session when the backend response didn't include a `banners` array (CP-12079). We now safely read the banners array and always release the pending request state so future loads proceed.

- **Bug Fixes**
  - Safely fetch `banners` via `[result cleverPushArrayForKey:@"banners"]` and reuse `rawBanners` for filtering/copying.
  - If the array is missing, reset `pendingBannerRequest` and `pendingBannerListeners` inside the lock and log an error to prevent session-wide deadlocks.

<sup>Written for commit 9b5513e33788ef23abf5e5091bebc0a8f6036f87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

