### PR TITLE
hotfix/CP-12080 - fix proper banner marking

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -1677,8 +1677,6 @@ int appBannerPerDayValue = 0;
         };
         [appBannerViewController setActionCallback:callbackBlock];
 
-        [self setBannerIsShown:banner];
-
         BOOL shouldUpdateBanners = [CPUtils isNullOrEmpty:currentEventId] || banner.frequency != CPAppBannerFrequencyEveryTrigger;
 
         if (shouldUpdateBanners) {
@@ -1722,6 +1720,10 @@ int appBannerPerDayValue = 0;
     }
 }
 
+- (void)presentAppBanner:(CPAppBannerViewController*)appBannerViewController banner:(CPAppBanner*)banner {
+    [self presentAppBanner:appBannerViewController banner:banner notificationId:nil force:NO];
+}
+
 - (void)presentAppBanner:(CPAppBannerViewController*)appBannerViewController banner:(CPAppBanner*)banner force:(BOOL)force {
     [self presentAppBanner:appBannerViewController banner:banner notificationId:nil force:force];
 }
@@ -1756,16 +1758,32 @@ int appBannerPerDayValue = 0;
         displayCallback = handleBannerDisplayed;
     }
     
+    BOOL presented = NO;
     if (displayCallback) {
         displayCallback(appBannerViewController);
+        presented = YES;
         if (banner.stopAtType == CPAppBannerStopAtTypeRelativeToDelivery) {
             [self setBannerFirstDisplayDate:banner];
         }
     } else if (appBannersNonBlocking) {
-        [self presentNonBlockingBanner:appBannerViewController banner:banner notificationId:notificationId force:force];
+        presented = [self presentNonBlockingBanner:appBannerViewController banner:banner notificationId:notificationId force:force];
     } else {
-        [self presentBlockingBanner:appBannerViewController banner:banner notificationId:notificationId force:force];
+        presented = [self presentBlockingBanner:appBannerViewController banner:banner notificationId:notificationId force:force];
     }
+
+    if (!presented) {
+        // Presentation bailed (e.g. no top view controller available yet). Reset the visible
+        // flag so subsequent banners are not queued forever, keep the banner unmarked so
+        // frequency "once" banners are not consumed without ever being displayed, and give
+        // any queued banners a chance to present.
+        [CPLog error:@"presentAppBanner: banner %@ could not be presented because no top view controller was found", banner.id];
+        [[NSUserDefaults standardUserDefaults] setBool:false forKey:CLEVERPUSH_APP_BANNER_VISIBLE_KEY];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+        [self showNextActivePendingBanner:banner];
+        return;
+    }
+
+    [self setBannerIsShown:banner];
 
     if (banner.dismissType == CPAppBannerDismissTypeTimeout) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * (long)banner.dismissTimeout), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
@@ -1784,15 +1802,15 @@ int appBannerPerDayValue = 0;
 }
 
 #pragma mark - Non-blocking banner presentation (child VC of top view controller)
-- (void)presentNonBlockingBanner:(CPAppBannerViewController*)appBannerViewController banner:(CPAppBanner*)banner notificationId:(NSString*)notificationId force:(BOOL)force {
+- (BOOL)presentNonBlockingBanner:(CPAppBannerViewController*)appBannerViewController banner:(CPAppBanner*)banner notificationId:(NSString*)notificationId force:(BOOL)force {
+    UIViewController *hostVC = [CleverPush topViewController];
+    if (!hostVC) {
+        return NO;
+    }
+
     if (!force && [CPUtils isNullOrEmpty:notificationId]) {
         [self incrementSessionBannerCount];
         [self incrementDailyBannerCount];
-    }
-    
-    UIViewController *hostVC = [CleverPush topViewController];
-    if (!hostVC) {
-        return;
     }
 
     CPAppBannerPassthroughView *overlay = [[CPAppBannerPassthroughView alloc] initWithFrame:hostVC.view.bounds];
@@ -1849,10 +1867,16 @@ int appBannerPerDayValue = 0;
     if (banner.stopAtType == CPAppBannerStopAtTypeRelativeToDelivery) {
         [self setBannerFirstDisplayDate:banner];
     }
+    return YES;
 }
 
 #pragma mark - Blocking banner presentation (default modal)
-- (void)presentBlockingBanner:(CPAppBannerViewController*)appBannerViewController banner:(CPAppBanner*)banner notificationId:(NSString*)notificationId force:(BOOL)force {
+- (BOOL)presentBlockingBanner:(CPAppBannerViewController*)appBannerViewController banner:(CPAppBanner*)banner notificationId:(NSString*)notificationId force:(BOOL)force {
+    UIViewController *topController = [CleverPush topViewController];
+    if (!topController) {
+        return NO;
+    }
+
     [appBannerViewController setModalPresentationStyle:[CleverPush getAppBannerModalPresentationStyle]];
     [appBannerViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
 
@@ -1861,10 +1885,6 @@ int appBannerPerDayValue = 0;
         [self incrementDailyBannerCount];
     }
 
-    UIViewController *topController = [CleverPush topViewController];
-    if (!topController) {
-        return;
-    }
     appBannerViewController.view.alpha = 0.0;
     [topController presentViewController:appBannerViewController animated:NO completion:^{
         [appBannerViewController finishSetup];
@@ -1879,6 +1899,7 @@ int appBannerPerDayValue = 0;
             [self setBannerFirstDisplayDate:banner];
         }
     }];
+    return YES;
 }
 
 #pragma mark - track the record of the banner callback events by calling an api (app-banner/event/@"event-name")

--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -253,13 +253,18 @@ CPNotificationClickBlock handleClick;
 }
 
 - (void)presentAppBanner:(CPInboxDetailView*)appBannerViewController  banner:(CPAppBanner*)banner {
+    UIViewController* topController = [CleverPush topViewController];
+    if (!topController) {
+        [CPLog error:@"CPInboxView: presentAppBanner: banner %@ could not be presented because no top view controller was found", banner.id];
+        return;
+    }
+
     [[NSUserDefaults standardUserDefaults] setBool:true forKey:CLEVERPUSH_APP_BANNER_VISIBLE_KEY];
     [[NSUserDefaults standardUserDefaults] synchronize];
     [appBannerViewController setModalPresentationStyle:[CleverPush getAppBannerModalPresentationStyle]];
     [appBannerViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
     appBannerViewController.data = banner;
 
-    UIViewController* topController = [CleverPush topViewController];
     [topController presentViewController:appBannerViewController animated:YES completion:nil];
 
     if (banner.dismissType == CPAppBannerDismissTypeTimeout) {

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -556,9 +556,13 @@ static id isNil(id object) {
 - (UIViewController* _Nullable)topViewController {
     if ([CleverPush getCustomTopViewController] != nil) {
         return [CleverPush getCustomTopViewController];
-    } else {
-        return [self topViewControllerWithRootViewController:[UIApplication sharedApplication].keyWindow.rootViewController];
     }
+
+    UIViewController* rootViewController = [self keyWindow].rootViewController;
+    if (!rootViewController) {
+        return nil;
+    }
+    return [self topViewControllerWithRootViewController:rootViewController];
 }
 
 - (UIViewController*)topViewControllerWithRootViewController:(UIViewController*)viewController {
@@ -4482,15 +4486,40 @@ static id isNil(id object) {
 }
 
 - (UIWindow*)keyWindow {
-    UIWindow*foundWindow = nil;
-    NSArray*windows = [[UIApplication sharedApplication] windows];
-    for (UIWindow*window in windows) {
-        if (window.isKeyWindow) {
-            foundWindow = window;
-            break;
+    UIWindow* fallbackWindow = nil;
+
+    // Scene-based lookup first: UIApplication.keyWindow is deprecated and frequently nil in
+    // SwiftUI / scene-lifecycle apps, which caused banners to fail presenting silently.
+    if (@available(iOS 13.0, *)) {
+        for (UIScene* scene in [UIApplication sharedApplication].connectedScenes) {
+            if (![scene isKindOfClass:[UIWindowScene class]]) {
+                continue;
+            }
+            if (scene.activationState != UISceneActivationStateForegroundActive
+                && scene.activationState != UISceneActivationStateForegroundInactive) {
+                continue;
+            }
+            for (UIWindow* window in ((UIWindowScene*)scene).windows) {
+                if (window.isKeyWindow) {
+                    return window;
+                }
+                if (!fallbackWindow && !window.isHidden && window.rootViewController != nil) {
+                    fallbackWindow = window;
+                }
+            }
         }
     }
-    return foundWindow;
+
+    NSArray* windows = [[UIApplication sharedApplication] windows];
+    for (UIWindow* window in windows) {
+        if (window.isKeyWindow) {
+            return window;
+        }
+        if (!fallbackWindow && !window.isHidden && window.rootViewController != nil) {
+            fallbackWindow = window;
+        }
+    }
+    return fallbackWindow;
 }
 
 #pragma mark - variable updates and callbacks


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes banner frequency/shown state and global presentation entry points; behavior is more correct but affects when once-only banners are consumed and when delivered events fire.
> 
> **Overview**
> Fixes app banners being marked as **shown** (including **once** frequency) before UI actually appears, and improves presentation when no host view controller is available.
> 
> **`setBannerIsShown`** now runs only after a successful present in **`presentAppBanner`**, not earlier in the show flow. Blocking and non-blocking presenters return **`BOOL`**; on failure the SDK clears **`CLEVERPUSH_APP_BANNER_VISIBLE_KEY`**, skips marking the banner shown, logs an error, and advances **`showNextActivePendingBanner`** so queues do not stall.
> 
> **`keyWindow`** / **`topViewController`** prefer foreground **`UIWindowScene`** windows (with a visible-window fallback) instead of deprecated **`keyWindow`**, which was often nil on SwiftUI/scene-lifecycle apps. Inbox banner presentation bails early with logging when no top controller exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fdc517be2377ca1126376f3c5024856a35d8c37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes banners being marked as shown before they are actually presented. Prevents “once” banners from being consumed without display and avoids stuck banner queues (CP-12080).

- **Bug Fixes**
  - Mark banner as shown only after a successful presentation; if presentation fails, reset visibility and try the next pending banner.
  - `presentBlockingBanner`/`presentNonBlockingBanner` now return a boolean and bail early when no top view controller exists; counts are only incremented on real presentations.
  - More robust key window/top view controller lookup for scene-based apps (iOS 13+), improving banner presentation reliability.
  - Inbox banner presentation now checks for a top view controller and logs an error if missing.

<sup>Written for commit 4fdc517be2377ca1126376f3c5024856a35d8c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

