### PR TITLE
hotfix/CP-12081 - fix

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -1043,7 +1043,7 @@ int appBannerPerDayValue = 0;
 
 #pragma mark - check the banner triggering allowed as per selected custom attributes.
 - (BOOL)checkRelationFilter:(NSString*)value compareWith:(NSString*)compareValue relation:(NSString*)relation isAllowed:(BOOL)allowed compareWithFrom:(NSString*)compareValueFrom compareWithTo:(NSString*)compareValueTo {
-    return [self checkRelationFilter:value compareWith:compareValue compareWithFrom:compareValue compareWithTo:compareValue relation:relation isAllowed:allowed];
+    return [self checkRelationFilter:value compareWith:compareValue compareWithFrom:compareValueFrom compareWithTo:compareValueTo relation:relation isAllowed:allowed];
 }
 
 #pragma mark - check the banner triggering allowed as per selected custom attributes.
@@ -1061,6 +1061,13 @@ int appBannerPerDayValue = 0;
         }
     } else if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeLessThan)]) {
         if (!CHECK_FILTER_LESS_THAN(value, compareValue)) {
+            allowed = NO;
+        }
+    } else if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeBetween)]) {
+        if ([CPUtils isNullOrEmpty:compareValueFrom] || [CPUtils isNullOrEmpty:compareValueTo]) {
+            // "between" without both bounds is a misconfiguration - skip the filter
+        } else if (!CHECK_FILTER_GREATER_THAN_OR_EQUAL_TO(value, compareValueFrom)
+                   || !CHECK_FILTER_LESS_THAN_OR_EQUAL_TO(value, compareValueTo)) {
             allowed = NO;
         }
     } else if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeNotEqual)]) {
@@ -1085,12 +1092,20 @@ int appBannerPerDayValue = 0;
 
 #pragma mark - check the banner triggering allowed as per selected version match with app version or not.
 - (BOOL)checkRelationAppVersionFilter:(NSString*)value compareWith:(NSString*)compareValue relation:(NSString*)relation isAllowed:(BOOL)allowed compareWithFrom:(NSString*)compareValueFrom compareWithTo:(NSString*)compareValueTo {
-    return [self checkRelationAppVersionFilter:value compareWith:compareValue compareWithFrom:compareValue compareWithTo:compareValue relation:relation isAllowed:allowed];
+    return [self checkRelationAppVersionFilter:value compareWith:compareValue compareWithFrom:compareValueFrom compareWithTo:compareValueTo relation:relation isAllowed:allowed];
 }
 
 #pragma mark - check the banner triggering allowed as per selected version match with app version or not.
 - (BOOL)checkRelationAppVersionFilter:(NSString*)value compareWith:(NSString*)compareValue compareWithFrom:(NSString*)compareValueFrom compareWithTo:(NSString*)compareValueTo relation:(NSString*)relation isAllowed:(BOOL)allowed {
-    if (relation == nil || compareValue == nil) {
+    if (relation == nil) {
+        return allowed;
+    }
+    if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeBetween)]) {
+        // "between" is configured via from/to and may not carry a single compare value
+        if ([CPUtils isNullOrEmpty:compareValueFrom] || [CPUtils isNullOrEmpty:compareValueTo]) {
+            return allowed;
+        }
+    } else if (compareValue == nil) {
         return allowed;
     }
     if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeEquals)]) {

--- a/CleverPush/Source/NSString+VersionComparator.m
+++ b/CleverPush/Source/NSString+VersionComparator.m
@@ -48,10 +48,7 @@ static NSString *versionSeparator = @".";
 }
 
 - (BOOL)isBetweenVersion:(NSString *)lowerVersion andVersion:(NSString *)upperVersion {
-    NSInteger versionToCheckInt = [self integerValue];
-    NSInteger lowerVersionInt = [lowerVersion integerValue];
-    NSInteger upperVersionInt = [upperVersion integerValue];
-    return (versionToCheckInt >= lowerVersionInt) && (versionToCheckInt <= upperVersionInt);
+    return [self isEqualOrNewerThanVersion:lowerVersion] && [self isEqualOrOlderThanVersion:upperVersion];
 }
 
 @end

--- a/CleverPushTests/CPAppBannerTest.m
+++ b/CleverPushTests/CPAppBannerTest.m
@@ -3,10 +3,16 @@
 #import "CPAppBannerViewController.h"
 #import "CPAppBannerModule.h"
 #import "CPAppBannerModuleInstance.h"
+#import "NSString+VersionComparator.h"
 #import "TestUtils.h"
 
 #import <OCMock/OCMock.h>
 @import XCTest;
+
+@interface CPAppBannerModuleInstance (CPRelationFilterTests)
+- (BOOL)checkRelationFilter:(NSString*)value compareWith:(NSString*)compareValue relation:(NSString*)relation isAllowed:(BOOL)allowed compareWithFrom:(NSString*)compareValueFrom compareWithTo:(NSString*)compareValueTo;
+- (BOOL)checkRelationAppVersionFilter:(NSString*)value compareWith:(NSString*)compareValue relation:(NSString*)relation isAllowed:(BOOL)allowed compareWithFrom:(NSString*)compareValueFrom compareWithTo:(NSString*)compareValueTo;
+@end
 @interface CPAppBannerTest : XCTestCase
 @property (nonatomic) CPAppBannerViewController *bannerTestController;
 @property (nonatomic, retain) CleverPushInstance *testableInstance;
@@ -134,7 +140,7 @@ dispatch_queue_t dispatchQueue = nil;
 }
 
 - (void)testInitSession {
-    [self.appBanner initSession];
+    [self.appBanner initSession:@"channel_id" afterInit:NO];
     XCTAssertEqual([self.appBanner getListOfBanners].count, 0);
     XCTAssertEqual([self.appBanner getPendingBannerListeners].count, 0);
     [[self.appBanner verify] saveSessions];
@@ -223,7 +229,7 @@ dispatch_queue_t dispatchQueue = nil;
 }
 
 - (void)testAndVerifyStartUpWithCreateAndScheduleBanners {
-    [self.appBanner initSession];
+    [self.appBanner initSession:@"channel_id" afterInit:NO];
     XCTAssertEqual([self.appBanner getListOfBanners].count, 0);
     XCTAssertEqual([self.appBanner getPendingBannerListeners].count, 0);
     [[self.appBanner verify] saveSessions];
@@ -329,6 +335,70 @@ dispatch_queue_t dispatchQueue = nil;
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
     }];
+}
+
+#pragma mark - CP-12081 between OS-version / app-version targeting
+
+- (void)testIsBetweenVersionComparesSegmentWise {
+    XCTAssertTrue([@"17.5.1" isBetweenVersion:@"16.0" andVersion:@"18.0"]);
+    XCTAssertFalse([@"15.9" isBetweenVersion:@"16.0" andVersion:@"18.0"]);
+    XCTAssertFalse([@"18.0.1" isBetweenVersion:@"16.0" andVersion:@"18.0"]);
+    // bounds are inclusive
+    XCTAssertTrue([@"16.0" isBetweenVersion:@"16.0" andVersion:@"18.0"]);
+    XCTAssertTrue([@"18.0" isBetweenVersion:@"16.0" andVersion:@"18.0"]);
+    // minor segments must not be truncated (integerValue would treat 17.5 as 17)
+    XCTAssertFalse([@"17.5" isBetweenVersion:@"17.0" andVersion:@"17.4"]);
+    XCTAssertTrue([@"17.5" isBetweenVersion:@"17.5" andVersion:@"17.5"]);
+}
+
+- (void)testCheckRelationAppVersionFilterBetweenInsideRange {
+    BOOL allowed = [self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"16.0" compareWithTo:@"18.0"];
+    XCTAssertTrue(allowed);
+}
+
+- (void)testCheckRelationAppVersionFilterBetweenOutsideRange {
+    BOOL allowed = [self.bannerInstance checkRelationAppVersionFilter:@"15.2" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"16.0" compareWithTo:@"18.0"];
+    XCTAssertFalse(allowed);
+}
+
+- (void)testCheckRelationAppVersionFilterBetweenWithNilTargetStillEvaluatesBounds {
+    // osTarget "between" entries carry from/to but often no single target value
+    BOOL allowed = [self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:nil relation:@"between" isAllowed:YES compareWithFrom:@"16.0" compareWithTo:@"18.0"];
+    XCTAssertTrue(allowed);
+    BOOL notAllowed = [self.bannerInstance checkRelationAppVersionFilter:@"19.0" compareWith:nil relation:@"between" isAllowed:YES compareWithFrom:@"16.0" compareWithTo:@"18.0"];
+    XCTAssertFalse(notAllowed);
+}
+
+- (void)testCheckRelationAppVersionFilterBetweenWithMissingBoundsSkipsFilter {
+    BOOL allowed = [self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"" compareWithTo:@""];
+    XCTAssertTrue(allowed);
+}
+
+- (void)testCheckRelationAppVersionFilterNonBetweenRelationsUnchanged {
+    XCTAssertTrue([self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:@"17.5.1" relation:@"equals" isAllowed:YES compareWithFrom:nil compareWithTo:nil]);
+    XCTAssertFalse([self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:@"17.5.2" relation:@"equals" isAllowed:YES compareWithFrom:nil compareWithTo:nil]);
+    XCTAssertTrue([self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:@"16.0" relation:@"greaterThan" isAllowed:YES compareWithFrom:nil compareWithTo:nil]);
+    XCTAssertTrue([self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:@"18.0" relation:@"lessThan" isAllowed:YES compareWithFrom:nil compareWithTo:nil]);
+}
+
+- (void)testCheckRelationFilterBetweenInsideAndOutsideRange {
+    // regression: attribute "between" had no branch at all and always passed
+    XCTAssertTrue([self.bannerInstance checkRelationFilter:@"25" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"18" compareWithTo:@"30"]);
+    XCTAssertFalse([self.bannerInstance checkRelationFilter:@"31" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"18" compareWithTo:@"30"]);
+    XCTAssertFalse([self.bannerInstance checkRelationFilter:@"17" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"18" compareWithTo:@"30"]);
+    // bounds are inclusive
+    XCTAssertTrue([self.bannerInstance checkRelationFilter:@"18" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"18" compareWithTo:@"30"]);
+    XCTAssertTrue([self.bannerInstance checkRelationFilter:@"30" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"18" compareWithTo:@"30"]);
+}
+
+- (void)testCheckRelationFilterBetweenWithMissingBoundsSkipsFilter {
+    XCTAssertTrue([self.bannerInstance checkRelationFilter:@"25" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"" compareWithTo:@""]);
+}
+
+- (void)testCheckRelationFilterEventTriggerStyleCallUnchanged {
+    // event triggers pass the compare value as from/to on purpose; equals must behave as before
+    XCTAssertTrue([self.bannerInstance checkRelationFilter:@"value" compareWith:@"value" relation:@"equals" isAllowed:YES compareWithFrom:@"value" compareWithTo:@"value"]);
+    XCTAssertFalse([self.bannerInstance checkRelationFilter:@"other" compareWith:@"value" relation:@"equals" isAllowed:YES compareWithFrom:@"value" compareWithTo:@"value"]);
 }
 
 @end

--- a/CleverPushTests/CPAttributesTests.m
+++ b/CleverPushTests/CPAttributesTests.m
@@ -36,29 +36,29 @@
     self.defaults = OCMPartialMock(self.userDefault);
 }
 - (void)testGetAvailableAttributes {
-    NSDictionary *responseObject = [[NSDictionary alloc]initWithObjectsAndKeys:@"value",@"key", nil];
-    NSDictionary *finalResponseObject = responseObject;
+    NSMutableArray *responseObject = [[NSMutableArray alloc]initWithObjects:@"value", nil];
+    NSMutableArray *finalResponseObject = responseObject;
     
     [OCMStub([self.cleverPush getAvailableAttributes:[OCMArg any]]) andDo:^(NSInvocation *invocation) {
-        void (^handler)(NSDictionary *myFirstArgument);
+        void (^ __unsafe_unretained handler)(NSMutableArray *myFirstArgument);
         [invocation getArgument:&handler atIndex:2];
         handler(finalResponseObject);
     }];
-    [self.cleverPush getAvailableAttributes:^(NSDictionary *configAttributes) {
+    [self.cleverPush getAvailableAttributes:^(NSMutableArray *configAttributes) {
         XCTAssertEqual(configAttributes, finalResponseObject);
     }];
     OCMVerify([self.cleverPush getAvailableAttributes:[OCMArg any]]);
 }
 
 - (void)testGetAvailableAttributesFromConfigWhenChannelConfigIsNull {
-    NSDictionary *finalResponseObject = [[NSDictionary alloc]init];
+    NSMutableArray *finalResponseObject = [[NSMutableArray alloc]init];
     
     [OCMStub([self.cleverPush getAvailableAttributes:[OCMArg any]]) andDo:^(NSInvocation *invocation) {
-        void (^handler)(NSDictionary *myFirstArgument);
+        void (^ __unsafe_unretained handler)(NSMutableArray *myFirstArgument);
         [invocation getArgument:&handler atIndex:2];
         handler(finalResponseObject);
     }];
-    [self.cleverPush getAvailableAttributes:^(NSDictionary *configAttributes) {
+    [self.cleverPush getAvailableAttributes:^(NSMutableArray *configAttributes) {
         XCTAssertEqual(configAttributes, finalResponseObject);
     }];
     OCMVerify([self.cleverPush getAvailableAttributes:[OCMArg any]]);

--- a/CleverPushTests/CPChannelConfigTest.m
+++ b/CleverPushTests/CPChannelConfigTest.m
@@ -115,13 +115,17 @@
 - (void)testAutoclearBadge {
     OCMStub([self.cleverPush getAutoClearBadge]).andReturn(true);
     (void)[self.cleverPush initWithLaunchOptions:nil channelId:@"channelId" handleNotificationReceived:nil handleNotificationOpened:nil autoRegister:true];
-    OCMVerify([self.cleverPush clearBadge:false]);
+    OCMVerify([self.cleverPush clearBadge]);
 }
 
 - (void)testSubscriptionIdIsNotNilAndNotificationNotEnableThanVerifyUnsubscribe {
     OCMStub([self.cleverPush subscriptionId]).andReturn(@"subscriptionId");
     OCMStub([self.cleverPush channelId]).andReturn(@"channelId");
-    OCMStub([self.cleverPush areNotificationsEnabled]).andReturn(false);
+    OCMStub([self.cleverPush areNotificationsEnabled:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+        void (^ __unsafe_unretained callback)(BOOL);
+        [invocation getArgument:&callback atIndex:2];
+        callback(NO);
+    });
     (void)[self.cleverPush initWithLaunchOptions:nil channelId:@"channelId" handleNotificationReceived:nil handleNotificationOpened:nil autoRegister:false];
     OCMVerify([self.cleverPush unsubscribe]);
 }
@@ -130,7 +134,11 @@
     OCMStub([self.cleverPush subscriptionId]).andReturn(@"subscriptionId");
     OCMStub([self.cleverPush channelId]).andReturn(@"channelId");
     OCMStub([self.cleverPush shouldSync]).andReturn(true);
-    OCMStub([self.cleverPush areNotificationsEnabled]).andReturn(true);
+    OCMStub([self.cleverPush areNotificationsEnabled:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+        void (^ __unsafe_unretained callback)(BOOL);
+        [invocation getArgument:&callback atIndex:2];
+        callback(YES);
+    });
     (void)[self.cleverPush initWithLaunchOptions:nil channelId:@"channelId" handleNotificationReceived:nil handleNotificationOpened:nil autoRegister:false];
     [_testUtilInstance performSelector:@selector(syncSubscription) withObject:self.cleverPush afterDelay:10.0f];
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes who sees app banners (targeting logic), but scope is focused on between filters and version parsing with new regression tests; misconfigured empty bounds intentionally skip the filter.
> 
> **Overview**
> Fixes **app banner targeting** when campaigns use a **between** relation for OS version, app version, or subscription attributes.
> 
> **Filter plumbing:** `checkRelationFilter` and `checkRelationAppVersionFilter` now forward real **from/to** bounds instead of duplicating the single compare value, which broke range rules. Custom-attribute **between** is implemented (it previously had no branch and always matched). App/OS **between** can run with a nil or empty target when only bounds are set; empty from/to is treated as misconfiguration and the filter is skipped rather than blocking the banner.
> 
> **Version comparison:** `isBetweenVersion` uses segment-wise semver-style comparison instead of `integerValue`, so values like `17.5` are not truncated to `17`.
> 
> **Tests:** Adds CP-12081 coverage for between/inclusive bounds and related regressions; other test files are updated for `initSession`, `getAvailableAttributes` as array, `clearBadge`, and async `areNotificationsEnabled`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 545bb2045d6b5a14837168562fe014ea0514c532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes “between” targeting for OS/app versions and custom attributes so ranges are evaluated correctly and inclusively. Addresses CP-12081 and prevents false positives by using proper segment-wise version comparison.

- **Bug Fixes**
  - Correctly pass `compareWithFrom`/`compareWithTo` to relation checks.
  - Add “between” handling for attributes; skip filter when bounds are missing.
  - Support “between” for app version/OS targeting via from/to bounds; allow nil single compare value; bounds are inclusive.
  - Update `-isBetweenVersion:andVersion:` to use segment-wise comparisons to avoid integer truncation.
  - Add tests for “between” logic and adjust stubs to current APIs (new `initSession` signature, `clearBadge` no-arg, async `areNotificationsEnabled`, attributes callback returns an array).

<sup>Written for commit 545bb2045d6b5a14837168562fe014ea0514c532. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

