### PR TITLE
hotfix / CP-12082 ios sdk banner initialization is gated on channel config

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -1043,7 +1043,7 @@ int appBannerPerDayValue = 0;
 
 #pragma mark - check the banner triggering allowed as per selected custom attributes.
 - (BOOL)checkRelationFilter:(NSString*)value compareWith:(NSString*)compareValue relation:(NSString*)relation isAllowed:(BOOL)allowed compareWithFrom:(NSString*)compareValueFrom compareWithTo:(NSString*)compareValueTo {
-    return [self checkRelationFilter:value compareWith:compareValue compareWithFrom:compareValue compareWithTo:compareValue relation:relation isAllowed:allowed];
+    return [self checkRelationFilter:value compareWith:compareValue compareWithFrom:compareValueFrom compareWithTo:compareValueTo relation:relation isAllowed:allowed];
 }
 
 #pragma mark - check the banner triggering allowed as per selected custom attributes.
@@ -1061,6 +1061,13 @@ int appBannerPerDayValue = 0;
         }
     } else if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeLessThan)]) {
         if (!CHECK_FILTER_LESS_THAN(value, compareValue)) {
+            allowed = NO;
+        }
+    } else if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeBetween)]) {
+        if ([CPUtils isNullOrEmpty:compareValueFrom] || [CPUtils isNullOrEmpty:compareValueTo]) {
+            // "between" without both bounds is a misconfiguration - skip the filter
+        } else if (!CHECK_FILTER_GREATER_THAN_OR_EQUAL_TO(value, compareValueFrom)
+                   || !CHECK_FILTER_LESS_THAN_OR_EQUAL_TO(value, compareValueTo)) {
             allowed = NO;
         }
     } else if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeNotEqual)]) {
@@ -1085,12 +1092,20 @@ int appBannerPerDayValue = 0;
 
 #pragma mark - check the banner triggering allowed as per selected version match with app version or not.
 - (BOOL)checkRelationAppVersionFilter:(NSString*)value compareWith:(NSString*)compareValue relation:(NSString*)relation isAllowed:(BOOL)allowed compareWithFrom:(NSString*)compareValueFrom compareWithTo:(NSString*)compareValueTo {
-    return [self checkRelationAppVersionFilter:value compareWith:compareValue compareWithFrom:compareValue compareWithTo:compareValue relation:relation isAllowed:allowed];
+    return [self checkRelationAppVersionFilter:value compareWith:compareValue compareWithFrom:compareValueFrom compareWithTo:compareValueTo relation:relation isAllowed:allowed];
 }
 
 #pragma mark - check the banner triggering allowed as per selected version match with app version or not.
 - (BOOL)checkRelationAppVersionFilter:(NSString*)value compareWith:(NSString*)compareValue compareWithFrom:(NSString*)compareValueFrom compareWithTo:(NSString*)compareValueTo relation:(NSString*)relation isAllowed:(BOOL)allowed {
-    if (relation == nil || compareValue == nil) {
+    if (relation == nil) {
+        return allowed;
+    }
+    if ([relation isEqualToString:filterRelationType(CPFilterRelationTypeBetween)]) {
+        // "between" is configured via from/to and may not carry a single compare value
+        if ([CPUtils isNullOrEmpty:compareValueFrom] || [CPUtils isNullOrEmpty:compareValueTo]) {
+            return allowed;
+        }
+    } else if (compareValue == nil) {
         return allowed;
     }
     if (allowed && [relation isEqualToString:filterRelationType(CPFilterRelationTypeEquals)]) {

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -716,11 +716,13 @@ static id isNil(id object) {
 
 	[self clearBadge];
 
-    [self getChannelConfig:^(NSDictionary * _Nullable result) {
-        if (result != nil) {
-            [CPAppBannerModule initSession:channelId afterInit:YES];
-        }
-    }];
+    NSString *sessionChannelId = channelId;
+    if ([CPUtils isNullOrEmpty:sessionChannelId]) {
+        sessionChannelId = [self getChannelIdFromUserDefaults];
+    }
+    if (![CPUtils isNullOrEmpty:sessionChannelId]) {
+        [CPAppBannerModule initSession:sessionChannelId afterInit:YES];
+    }
     
     [self areNotificationsEnabled:^(BOOL notificationsEnabled) {
         if (subscriptionId == nil) {
@@ -751,12 +753,14 @@ static id isNil(id object) {
         [self initAppReview];
 
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self getChannelConfig:^(NSDictionary * _Nullable result) {
-                if (result != nil) {
-                    [CPAppBannerModule initBannersWithChannel:channelId showDrafts:isShowDraft fromNotification:NO];
-                    [CPAppBannerModule initSession:channelId afterInit:NO];
-                }
-            }];
+            NSString *bannerChannelId = channelId;
+            if ([CPUtils isNullOrEmpty:bannerChannelId]) {
+                bannerChannelId = [self getChannelIdFromUserDefaults];
+            }
+            if (![CPUtils isNullOrEmpty:bannerChannelId]) {
+                [CPAppBannerModule initBannersWithChannel:bannerChannelId showDrafts:isShowDraft fromNotification:NO];
+                [CPAppBannerModule initSession:bannerChannelId afterInit:NO];
+            }
         });
     });
 }

--- a/CleverPush/Source/NSString+VersionComparator.m
+++ b/CleverPush/Source/NSString+VersionComparator.m
@@ -48,10 +48,7 @@ static NSString *versionSeparator = @".";
 }
 
 - (BOOL)isBetweenVersion:(NSString *)lowerVersion andVersion:(NSString *)upperVersion {
-    NSInteger versionToCheckInt = [self integerValue];
-    NSInteger lowerVersionInt = [lowerVersion integerValue];
-    NSInteger upperVersionInt = [upperVersion integerValue];
-    return (versionToCheckInt >= lowerVersionInt) && (versionToCheckInt <= upperVersionInt);
+    return [self isEqualOrNewerThanVersion:lowerVersion] && [self isEqualOrOlderThanVersion:upperVersion];
 }
 
 @end

--- a/CleverPushTests/CPAppBannerTest.m
+++ b/CleverPushTests/CPAppBannerTest.m
@@ -3,10 +3,16 @@
 #import "CPAppBannerViewController.h"
 #import "CPAppBannerModule.h"
 #import "CPAppBannerModuleInstance.h"
+#import "NSString+VersionComparator.h"
 #import "TestUtils.h"
 
 #import <OCMock/OCMock.h>
 @import XCTest;
+
+@interface CPAppBannerModuleInstance (CPRelationFilterTests)
+- (BOOL)checkRelationFilter:(NSString*)value compareWith:(NSString*)compareValue relation:(NSString*)relation isAllowed:(BOOL)allowed compareWithFrom:(NSString*)compareValueFrom compareWithTo:(NSString*)compareValueTo;
+- (BOOL)checkRelationAppVersionFilter:(NSString*)value compareWith:(NSString*)compareValue relation:(NSString*)relation isAllowed:(BOOL)allowed compareWithFrom:(NSString*)compareValueFrom compareWithTo:(NSString*)compareValueTo;
+@end
 @interface CPAppBannerTest : XCTestCase
 @property (nonatomic) CPAppBannerViewController *bannerTestController;
 @property (nonatomic, retain) CleverPushInstance *testableInstance;
@@ -134,7 +140,7 @@ dispatch_queue_t dispatchQueue = nil;
 }
 
 - (void)testInitSession {
-    [self.appBanner initSession];
+    [self.appBanner initSession:@"channel_id" afterInit:NO];
     XCTAssertEqual([self.appBanner getListOfBanners].count, 0);
     XCTAssertEqual([self.appBanner getPendingBannerListeners].count, 0);
     [[self.appBanner verify] saveSessions];
@@ -223,7 +229,7 @@ dispatch_queue_t dispatchQueue = nil;
 }
 
 - (void)testAndVerifyStartUpWithCreateAndScheduleBanners {
-    [self.appBanner initSession];
+    [self.appBanner initSession:@"channel_id" afterInit:NO];
     XCTAssertEqual([self.appBanner getListOfBanners].count, 0);
     XCTAssertEqual([self.appBanner getPendingBannerListeners].count, 0);
     [[self.appBanner verify] saveSessions];
@@ -329,6 +335,70 @@ dispatch_queue_t dispatchQueue = nil;
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
     }];
+}
+
+#pragma mark - CP-12081 between OS-version / app-version targeting
+
+- (void)testIsBetweenVersionComparesSegmentWise {
+    XCTAssertTrue([@"17.5.1" isBetweenVersion:@"16.0" andVersion:@"18.0"]);
+    XCTAssertFalse([@"15.9" isBetweenVersion:@"16.0" andVersion:@"18.0"]);
+    XCTAssertFalse([@"18.0.1" isBetweenVersion:@"16.0" andVersion:@"18.0"]);
+    // bounds are inclusive
+    XCTAssertTrue([@"16.0" isBetweenVersion:@"16.0" andVersion:@"18.0"]);
+    XCTAssertTrue([@"18.0" isBetweenVersion:@"16.0" andVersion:@"18.0"]);
+    // minor segments must not be truncated (integerValue would treat 17.5 as 17)
+    XCTAssertFalse([@"17.5" isBetweenVersion:@"17.0" andVersion:@"17.4"]);
+    XCTAssertTrue([@"17.5" isBetweenVersion:@"17.5" andVersion:@"17.5"]);
+}
+
+- (void)testCheckRelationAppVersionFilterBetweenInsideRange {
+    BOOL allowed = [self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"16.0" compareWithTo:@"18.0"];
+    XCTAssertTrue(allowed);
+}
+
+- (void)testCheckRelationAppVersionFilterBetweenOutsideRange {
+    BOOL allowed = [self.bannerInstance checkRelationAppVersionFilter:@"15.2" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"16.0" compareWithTo:@"18.0"];
+    XCTAssertFalse(allowed);
+}
+
+- (void)testCheckRelationAppVersionFilterBetweenWithNilTargetStillEvaluatesBounds {
+    // osTarget "between" entries carry from/to but often no single target value
+    BOOL allowed = [self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:nil relation:@"between" isAllowed:YES compareWithFrom:@"16.0" compareWithTo:@"18.0"];
+    XCTAssertTrue(allowed);
+    BOOL notAllowed = [self.bannerInstance checkRelationAppVersionFilter:@"19.0" compareWith:nil relation:@"between" isAllowed:YES compareWithFrom:@"16.0" compareWithTo:@"18.0"];
+    XCTAssertFalse(notAllowed);
+}
+
+- (void)testCheckRelationAppVersionFilterBetweenWithMissingBoundsSkipsFilter {
+    BOOL allowed = [self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"" compareWithTo:@""];
+    XCTAssertTrue(allowed);
+}
+
+- (void)testCheckRelationAppVersionFilterNonBetweenRelationsUnchanged {
+    XCTAssertTrue([self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:@"17.5.1" relation:@"equals" isAllowed:YES compareWithFrom:nil compareWithTo:nil]);
+    XCTAssertFalse([self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:@"17.5.2" relation:@"equals" isAllowed:YES compareWithFrom:nil compareWithTo:nil]);
+    XCTAssertTrue([self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:@"16.0" relation:@"greaterThan" isAllowed:YES compareWithFrom:nil compareWithTo:nil]);
+    XCTAssertTrue([self.bannerInstance checkRelationAppVersionFilter:@"17.5.1" compareWith:@"18.0" relation:@"lessThan" isAllowed:YES compareWithFrom:nil compareWithTo:nil]);
+}
+
+- (void)testCheckRelationFilterBetweenInsideAndOutsideRange {
+    // regression: attribute "between" had no branch at all and always passed
+    XCTAssertTrue([self.bannerInstance checkRelationFilter:@"25" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"18" compareWithTo:@"30"]);
+    XCTAssertFalse([self.bannerInstance checkRelationFilter:@"31" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"18" compareWithTo:@"30"]);
+    XCTAssertFalse([self.bannerInstance checkRelationFilter:@"17" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"18" compareWithTo:@"30"]);
+    // bounds are inclusive
+    XCTAssertTrue([self.bannerInstance checkRelationFilter:@"18" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"18" compareWithTo:@"30"]);
+    XCTAssertTrue([self.bannerInstance checkRelationFilter:@"30" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"18" compareWithTo:@"30"]);
+}
+
+- (void)testCheckRelationFilterBetweenWithMissingBoundsSkipsFilter {
+    XCTAssertTrue([self.bannerInstance checkRelationFilter:@"25" compareWith:@"" relation:@"between" isAllowed:YES compareWithFrom:@"" compareWithTo:@""]);
+}
+
+- (void)testCheckRelationFilterEventTriggerStyleCallUnchanged {
+    // event triggers pass the compare value as from/to on purpose; equals must behave as before
+    XCTAssertTrue([self.bannerInstance checkRelationFilter:@"value" compareWith:@"value" relation:@"equals" isAllowed:YES compareWithFrom:@"value" compareWithTo:@"value"]);
+    XCTAssertFalse([self.bannerInstance checkRelationFilter:@"other" compareWith:@"value" relation:@"equals" isAllowed:YES compareWithFrom:@"value" compareWithTo:@"value"]);
 }
 
 @end

--- a/CleverPushTests/CPAttributesTests.m
+++ b/CleverPushTests/CPAttributesTests.m
@@ -36,29 +36,29 @@
     self.defaults = OCMPartialMock(self.userDefault);
 }
 - (void)testGetAvailableAttributes {
-    NSDictionary *responseObject = [[NSDictionary alloc]initWithObjectsAndKeys:@"value",@"key", nil];
-    NSDictionary *finalResponseObject = responseObject;
+    NSMutableArray *responseObject = [[NSMutableArray alloc]initWithObjects:@"value", nil];
+    NSMutableArray *finalResponseObject = responseObject;
     
     [OCMStub([self.cleverPush getAvailableAttributes:[OCMArg any]]) andDo:^(NSInvocation *invocation) {
-        void (^handler)(NSDictionary *myFirstArgument);
+        void (^ __unsafe_unretained handler)(NSMutableArray *myFirstArgument);
         [invocation getArgument:&handler atIndex:2];
         handler(finalResponseObject);
     }];
-    [self.cleverPush getAvailableAttributes:^(NSDictionary *configAttributes) {
+    [self.cleverPush getAvailableAttributes:^(NSMutableArray *configAttributes) {
         XCTAssertEqual(configAttributes, finalResponseObject);
     }];
     OCMVerify([self.cleverPush getAvailableAttributes:[OCMArg any]]);
 }
 
 - (void)testGetAvailableAttributesFromConfigWhenChannelConfigIsNull {
-    NSDictionary *finalResponseObject = [[NSDictionary alloc]init];
+    NSMutableArray *finalResponseObject = [[NSMutableArray alloc]init];
     
     [OCMStub([self.cleverPush getAvailableAttributes:[OCMArg any]]) andDo:^(NSInvocation *invocation) {
-        void (^handler)(NSDictionary *myFirstArgument);
+        void (^ __unsafe_unretained handler)(NSMutableArray *myFirstArgument);
         [invocation getArgument:&handler atIndex:2];
         handler(finalResponseObject);
     }];
-    [self.cleverPush getAvailableAttributes:^(NSDictionary *configAttributes) {
+    [self.cleverPush getAvailableAttributes:^(NSMutableArray *configAttributes) {
         XCTAssertEqual(configAttributes, finalResponseObject);
     }];
     OCMVerify([self.cleverPush getAvailableAttributes:[OCMArg any]]);

--- a/CleverPushTests/CPChannelConfigTest.m
+++ b/CleverPushTests/CPChannelConfigTest.m
@@ -115,13 +115,17 @@
 - (void)testAutoclearBadge {
     OCMStub([self.cleverPush getAutoClearBadge]).andReturn(true);
     (void)[self.cleverPush initWithLaunchOptions:nil channelId:@"channelId" handleNotificationReceived:nil handleNotificationOpened:nil autoRegister:true];
-    OCMVerify([self.cleverPush clearBadge:false]);
+    OCMVerify([self.cleverPush clearBadge]);
 }
 
 - (void)testSubscriptionIdIsNotNilAndNotificationNotEnableThanVerifyUnsubscribe {
     OCMStub([self.cleverPush subscriptionId]).andReturn(@"subscriptionId");
     OCMStub([self.cleverPush channelId]).andReturn(@"channelId");
-    OCMStub([self.cleverPush areNotificationsEnabled]).andReturn(false);
+    OCMStub([self.cleverPush areNotificationsEnabled:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+        void (^ __unsafe_unretained callback)(BOOL);
+        [invocation getArgument:&callback atIndex:2];
+        callback(NO);
+    });
     (void)[self.cleverPush initWithLaunchOptions:nil channelId:@"channelId" handleNotificationReceived:nil handleNotificationOpened:nil autoRegister:false];
     OCMVerify([self.cleverPush unsubscribe]);
 }
@@ -130,7 +134,11 @@
     OCMStub([self.cleverPush subscriptionId]).andReturn(@"subscriptionId");
     OCMStub([self.cleverPush channelId]).andReturn(@"channelId");
     OCMStub([self.cleverPush shouldSync]).andReturn(true);
-    OCMStub([self.cleverPush areNotificationsEnabled]).andReturn(true);
+    OCMStub([self.cleverPush areNotificationsEnabled:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+        void (^ __unsafe_unretained callback)(BOOL);
+        [invocation getArgument:&callback atIndex:2];
+        callback(YES);
+    });
     (void)[self.cleverPush initWithLaunchOptions:nil channelId:@"channelId" handleNotificationReceived:nil handleNotificationOpened:nil autoRegister:false];
     [_testUtilInstance performSelector:@selector(syncSubscription) withObject:self.cleverPush afterDelay:10.0f];
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes banner initialization timing and targeting logic used for in-app messaging; misconfigured between bounds now pass through instead of failing closed, which could widen who sees banners.
> 
> **Overview**
> **Banner startup** no longer waits on a successful `getChannelConfig` callback. `initFeatures` and `applicationDidBecomeActive` now resolve a channel ID from memory or `getChannelIdFromUserDefaults` and call `initBannersWithChannel` / `initSession` when that ID is present.
> 
> **“Between” targeting** is fixed for custom attributes and app/OS version filters: wrapper methods forward real `from`/`to` bounds instead of duplicating `compareValue`, attribute filters get a new inclusive **between** branch, and app-version **between** works when `compareValue` is nil and skips when bounds are missing. `isBetweenVersion:` now uses segment-wise semver comparison instead of `integerValue` (so e.g. `17.5` is not treated as `17`).
> 
> Tests cover between ranges, missing bounds, and updated mocks for `initSession:`, `clearBadge`, and `areNotificationsEnabled:`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39515b239e03a9bf3b83b45baccd3523c066313d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop gating app banner initialization on channel config (CP-12082). Also fixes "between" filters for attributes and app/OS version targeting with correct segment-wise version comparison (CP-12081).

- **Bug Fixes**
  - Initialize banners/session using `channelId` or stored channel id without waiting for channel config in appDidBecomeActive and initFeatures.
  - Fix relation filters: correct from/to parameter usage and add "between" with inclusive bounds; skip when bounds are missing.
  - App/version targeting: support "between" via from/to even if compare value is nil; use segment-wise comparison; `isBetweenVersion` now uses >= and <= helpers.
  - Tests updated to cover "between" cases, new `initSession(channelId, afterInit)` API, async notification checks, and attribute API expectations.

<sup>Written for commit 39515b239e03a9bf3b83b45baccd3523c066313d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

