### PR TITLE
hotfix/CP-12084 - fix scrollable in non blocking app banners

### DIFF
--- a/CleverPush/Source/CPAppBannerModuleInstance.m
+++ b/CleverPush/Source/CPAppBannerModuleInstance.m
@@ -31,6 +31,7 @@ CPAppBannerClosedBlock handleBannerClosed;
 CPSQLiteManager *sqlManager;
 CPAppBannerDisplayBlock handleBannerDisplayed;
 CPAppBannerPassthroughView *activeBannerOverlay;
+UIWindow *activeBannerWindow;
 
 static NSObject *callbackLock;
 static NSObject *bannerRequestLock;
@@ -1784,13 +1785,64 @@ int appBannerPerDayValue = 0;
 }
 
 #pragma mark - Non-blocking banner presentation (child VC of top view controller)
+- (UIWindow *)ensureAppBannerPresentationWindow {
+    if (activeBannerWindow != nil) {
+        return activeBannerWindow;
+    }
+
+    if (@available(iOS 13.0, *)) {
+        UIWindowScene *scene = nil;
+        for (UIScene *connectedScene in UIApplication.sharedApplication.connectedScenes) {
+            if ([connectedScene isKindOfClass:[UIWindowScene class]] && connectedScene.activationState == UISceneActivationStateForegroundActive) {
+                scene = (UIWindowScene *)connectedScene;
+                break;
+            }
+        }
+        if (scene == nil) {
+            scene = (UIWindowScene *)[UIApplication.sharedApplication.connectedScenes anyObject];
+        }
+        if (scene != nil) {
+            activeBannerWindow = [[UIWindow alloc] initWithWindowScene:scene];
+        }
+    }
+
+    if (activeBannerWindow == nil) {
+        activeBannerWindow = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+    }
+
+    activeBannerWindow.frame = UIScreen.mainScreen.bounds;
+    activeBannerWindow.windowLevel = UIWindowLevelAlert + 1;
+    activeBannerWindow.backgroundColor = [UIColor clearColor];
+
+    UIViewController *rootViewController = [[UIViewController alloc] init];
+    rootViewController.view.backgroundColor = [UIColor clearColor];
+    activeBannerWindow.rootViewController = rootViewController;
+    activeBannerWindow.hidden = NO;
+
+    return activeBannerWindow;
+}
+
+- (void)teardownAppBannerPresentationWindow {
+    if (activeBannerOverlay != nil) {
+        [activeBannerOverlay removeFromSuperview];
+        activeBannerOverlay = nil;
+    }
+
+    if (activeBannerWindow != nil) {
+        activeBannerWindow.hidden = YES;
+        activeBannerWindow.rootViewController = nil;
+        activeBannerWindow = nil;
+    }
+}
+
 - (void)presentNonBlockingBanner:(CPAppBannerViewController*)appBannerViewController banner:(CPAppBanner*)banner notificationId:(NSString*)notificationId force:(BOOL)force {
     if (!force && [CPUtils isNullOrEmpty:notificationId]) {
         [self incrementSessionBannerCount];
         [self incrementDailyBannerCount];
     }
-    
-    UIViewController *hostVC = [CleverPush topViewController];
+
+    UIWindow *bannerWindow = [self ensureAppBannerPresentationWindow];
+    UIViewController *hostVC = bannerWindow.rootViewController;
     if (!hostVC) {
         return;
     }
@@ -1839,11 +1891,15 @@ int appBannerPerDayValue = 0;
         appBannerViewController.view.alpha = 1.0;
     }];
 
+    if ([banner.contentType isEqualToString:@"html"]) {
+        [appBannerViewController updateHTMLBannerLayoutForHostBounds:overlay.bounds];
+    }
+
     appBannerViewController.windowDismissBlock = ^{
         [weakBannerVC willMoveToParentViewController:nil];
         [weakOverlay removeFromSuperview];
         [weakBannerVC removeFromParentViewController];
-        activeBannerOverlay = nil;
+        [self teardownAppBannerPresentationWindow];
     };
 
     if (banner.stopAtType == CPAppBannerStopAtTypeRelativeToDelivery) {
@@ -1853,7 +1909,7 @@ int appBannerPerDayValue = 0;
 
 #pragma mark - Blocking banner presentation (default modal)
 - (void)presentBlockingBanner:(CPAppBannerViewController*)appBannerViewController banner:(CPAppBanner*)banner notificationId:(NSString*)notificationId force:(BOOL)force {
-    [appBannerViewController setModalPresentationStyle:[CleverPush getAppBannerModalPresentationStyle]];
+    [appBannerViewController setModalPresentationStyle:UIModalPresentationOverFullScreen];
     [appBannerViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
 
     if (!force && [CPUtils isNullOrEmpty:notificationId]) {
@@ -1861,16 +1917,28 @@ int appBannerPerDayValue = 0;
         [self incrementDailyBannerCount];
     }
 
-    UIViewController *topController = [CleverPush topViewController];
-    if (!topController) {
+    UIWindow *bannerWindow = [self ensureAppBannerPresentationWindow];
+    UIViewController *hostVC = bannerWindow.rootViewController;
+    if (!hostVC) {
         return;
     }
+
+    __weak CPAppBannerViewController *weakBannerVC = appBannerViewController;
     appBannerViewController.view.alpha = 0.0;
-    [topController presentViewController:appBannerViewController animated:NO completion:^{
+    appBannerViewController.windowDismissBlock = ^{
+        [weakBannerVC dismissViewControllerAnimated:NO completion:^{
+            [self teardownAppBannerPresentationWindow];
+        }];
+    };
+
+    [hostVC presentViewController:appBannerViewController animated:NO completion:^{
         [appBannerViewController finishSetup];
         if (!appBannerViewController.isPreloading) {
             [appBannerViewController.cardCollectionView reloadData];
             [appBannerViewController setBackground];
+            if ([banner.contentType isEqualToString:@"html"]) {
+                [appBannerViewController updateHTMLBannerLayoutForHostBounds:bannerWindow.bounds];
+            }
             [UIView animateWithDuration:0.3 animations:^{
                 appBannerViewController.view.alpha = 1.0;
             }];

--- a/CleverPush/Source/CPAppBannerViewController.h
+++ b/CleverPush/Source/CPAppBannerViewController.h
@@ -60,6 +60,7 @@
 #pragma mark - Class Methods
 - (void)initWithBanner:(CPAppBanner*)banner;
 - (void)initWithHTMLBanner:(CPAppBanner*)banner;
+- (void)updateHTMLBannerLayoutForHostBounds:(CGRect)bounds;
 - (void)setActionCallback:(CPAppBannerActionBlock)callback;
 - (void)actionCallback:(CPAppBannerAction*)action;
 - (void)onDismiss;

--- a/CleverPush/Source/CPAppBannerViewController.m
+++ b/CleverPush/Source/CPAppBannerViewController.m
@@ -341,6 +341,29 @@ static CPAppBannerActionBlock appBannerActionCallback;
     }
 }
 
+- (void)updateHTMLBannerLayoutForHostBounds:(CGRect)bounds {
+    if (![self.data.contentType isEqualToString:@"html"] || self.webView == nil) {
+        return;
+    }
+    if (bounds.size.width <= 0 || bounds.size.height <= 0) {
+        return;
+    }
+
+    self.webBannerHeight.constant = bounds.size.height;
+    if (self.webBannerWidth) {
+        self.webBannerWidth.constant = bounds.size.width;
+    }
+    [self.view layoutIfNeeded];
+
+    if (self.data.closeButtonEnabled && self.htmlCloseButton) {
+        [self updateCloseButtonForSize:bounds.size];
+    }
+
+    if ([CleverPush getAppBannersNonBlocking]) {
+        [self updateHTMLBannerTouchableRects];
+    }
+}
+
 #pragma mark - Update the UI while the device detects rotation.
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     if ([self.data.contentType isEqualToString:@"html"]) {
@@ -767,7 +790,12 @@ static CPAppBannerActionBlock appBannerActionCallback;
 
     config.userContentController = userController;
 
-    self.webView = [[WKWebView alloc] initWithFrame:CGRectMake(0, 0, [UIApplication sharedApplication].keyWindow.rootViewController.view.frame.size.width, [UIApplication sharedApplication].keyWindow.rootViewController.view.frame.size.height) configuration:config];
+    UIWindow *hostWindow = [CPUtils cleverPushKeyWindow];
+    CGRect hostBounds = [CPUtils bannerHostBoundsForWindow:hostWindow];
+    CGFloat bannerWidth = hostBounds.size.width;
+    CGFloat bannerHeight = hostBounds.size.height;
+
+    self.webView = [[WKWebView alloc] initWithFrame:CGRectMake(0, 0, bannerWidth, bannerHeight) configuration:config];
     self.webView.scrollView.scrollEnabled = true;
     self.webView.navigationDelegate = self;
     self.webView.backgroundColor = [UIColor clearColor];
@@ -775,19 +803,16 @@ static CPAppBannerActionBlock appBannerActionCallback;
     [CPUtils configureWebView:self.webView];
     [self setActionCallback:self.actionCallback];
 
-    self.webBannerHeight.constant = [UIApplication sharedApplication].keyWindow.rootViewController.view.frame.size.height;
+    self.webBannerHeight.constant = bannerHeight;
 
     if (self.data.closeButtonEnabled) {
         UIColor *backgroundColor;
         self.htmlCloseButton = [[UIButton alloc] init];
-        UIWindow *window = [UIApplication sharedApplication].keyWindow;
-        CGRect frame = window.rootViewController.view.frame;
-        CGFloat width = frame.size.width;
-        CGFloat height = frame.size.height;
-        CGFloat topPadding = 0;
+        CGFloat width = bannerWidth;
+        CGFloat height = bannerHeight;
+        CGFloat topPadding = hostWindow ? hostWindow.safeAreaInsets.top : 0;
         CGFloat spacing = 10;
 
-        topPadding = window.safeAreaInsets.top;
         self.htmlCloseButton = [[UIButton alloc] initWithFrame:(CGRectMake(width - 40 - spacing, topPadding + spacing, 40, 40))];
         if (self.data.closeButtonPositionStaticEnabled) {
             self.webView = [[WKWebView alloc] initWithFrame:CGRectMake(0, topPadding + 40 + spacing, width, height) configuration:config];

--- a/CleverPush/Source/CPUtils.h
+++ b/CleverPush/Source/CPUtils.h
@@ -22,6 +22,8 @@
 + (BOOL)isEmpty:(id)thing;
 + (void)openSafari:(NSURL*)URL;
 + (CGFloat)frameHeightWithoutSafeArea;
++ (UIWindow *)cleverPushKeyWindow;
++ (CGRect)bannerHostBoundsForWindow:(UIWindow *)window;
 + (void)openSafari:(NSURL*)URL dismissViewController:(UIViewController*)controller;
 + (void)handleLinkBySystem:(NSString*)urlString;
 + (NSString*)deviceName;

--- a/CleverPush/Source/CPUtils.m
+++ b/CleverPush/Source/CPUtils.m
@@ -293,11 +293,30 @@ NSString * const localeIdentifier = @"en_US_POSIX";
 
 #pragma mark -  Frame height without safeArea.
 + (CGFloat)frameHeightWithoutSafeArea {
-    UIWindow *window = UIApplication.sharedApplication.windows.firstObject;
+    UIWindow *window = [self cleverPushKeyWindow];
+    if (!window) {
+        return UIScreen.mainScreen.bounds.size.height;
+    }
     CGFloat topPadding = window.safeAreaInsets.top;
     CGFloat bottomPadding = window.safeAreaInsets.bottom;
     CGFloat height = UIScreen.mainScreen.bounds.size.height - (topPadding + bottomPadding);
     return height;
+}
+
++ (UIWindow *)cleverPushKeyWindow {
+    for (UIWindow *window in UIApplication.sharedApplication.windows) {
+        if (window.isKeyWindow) {
+            return window;
+        }
+    }
+    return UIApplication.sharedApplication.windows.firstObject;
+}
+
++ (CGRect)bannerHostBoundsForWindow:(UIWindow *)window {
+    if (window) {
+        return window.bounds;
+    }
+    return UIScreen.mainScreen.bounds;
 }
 
 #pragma mark -  Open safari and dismiss on a specific controller.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes global banner presentation and window lifecycle for all blocking/non-blocking banners; regressions could affect dismissal, z-order, or touches behind HTML banners.
> 
> **Overview**
> **App banners** (blocking and non-blocking) are no longer hosted on `[CleverPush topViewController]`. They now use a dedicated **`UIWindow`** at `UIWindowLevelAlert + 1`, with **`ensureAppBannerPresentationWindow`** / **`teardownAppBannerPresentationWindow`** on show and dismiss.
> 
> **Non-blocking** overlays attach to that window’s root VC; dismiss tears down the overlay and window. **Blocking** modals are presented from the same window with **`UIModalPresentationOverFullScreen`** (replacing the configurable modal style on the app’s top VC).
> 
> **HTML banners** get **`updateHTMLBannerLayoutForHostBounds:`** so the `WKWebView` and constraints match the real host bounds after presentation—supporting scroll and correct touch passthrough for non-blocking HTML. **`composeHTML`** sizes the web view via new **`CPUtils`** helpers **`cleverPushKeyWindow`** and **`bannerHostBoundsForWindow:`** instead of `keyWindow` directly; **`frameHeightWithoutSafeArea`** uses the same key-window resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa6ffd03df7113107c985ef9d221bd1e0d9f45ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes scroll issues in non-blocking app banners by rendering them in a dedicated, transparent UIWindow and sizing HTML banners to the host bounds. Addresses CP-12084 and ensures correct scrolling, safe-area positioning, and consistent sizing on iOS 13+.

- **Bug Fixes**
  - Present banners via a temporary UIWindow tied to the active UIWindowScene; tear down on dismiss.
  - Size HTML banners/WebViews to the host window; update layout on show/rotation; place the close button within safe areas.
  - Restores scrolling in non-blocking HTML banners and avoids unintended full-screen web views.

- **Refactors**
  - Added utils: cleverPushKeyWindow and bannerHostBoundsForWindow.
  - Added VC API: updateHTMLBannerLayoutForHostBounds.
  - Blocking banners now use UIModalPresentationOverFullScreen and present from window.rootViewController.

<sup>Written for commit fa6ffd03df7113107c985ef9d221bd1e0d9f45ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

