### PR TITLE
feature/cp-11978-support-platform-specific-font-names-for-in-app-banners

### DIFF
--- a/CleverPush/Source/CPAppBannerButtonBlock.h
+++ b/CleverPush/Source/CPAppBannerButtonBlock.h
@@ -15,6 +15,7 @@
 @property (nonatomic, strong) NSString *background;
 @property (nonatomic, strong) NSString *darkBackground;
 @property (nonatomic, strong) NSString *family;
+@property (nonatomic, strong) NSString *fontFamilyIos;
 @property (nonatomic, strong) NSString *id;
 @property (nonatomic, strong) NSString *borderColor;
 @property (nonatomic, strong) NSString *borderStyle;

--- a/CleverPush/Source/CPAppBannerButtonBlock.m
+++ b/CleverPush/Source/CPAppBannerButtonBlock.m
@@ -1,5 +1,6 @@
 #import "CPAppBannerButtonBlock.h"
 #import "NSDictionary+SafeExpectations.h"
+#import "CPUtils.h"
 
 @implementation CPAppBannerButtonBlock
 #pragma mark - wrapping the data of the Banner Button Block in to CPAppBannerButtonBlock NSObject
@@ -26,6 +27,11 @@
 
         if ([json cleverPushStringForKey:@"family"] && ![[json cleverPushStringForKey:@"family"] isEqual:@""]) {
             self.family = [json cleverPushStringForKey:@"family"];
+        }
+
+        NSString *fontFamilyIos = [json cleverPushStringForKey:@"fontFamilyIos"];
+        if (![CPUtils isNullOrEmpty:fontFamilyIos]) {
+            self.fontFamilyIos = fontFamilyIos;
         }
 
         if ([json cleverPushStringForKey:@"background"] && ![[json cleverPushStringForKey:@"background"] isEqual:@""]) {

--- a/CleverPush/Source/CPAppBannerTextBlock.h
+++ b/CleverPush/Source/CPAppBannerTextBlock.h
@@ -15,6 +15,7 @@
 @property (nonatomic, strong) NSString *color;
 @property (nonatomic, strong) NSString *darkColor;
 @property (nonatomic, strong) NSString *family;
+@property (nonatomic, strong) NSString *fontFamilyIos;
 @property (nonatomic) int size;
 
 #pragma mark - Class Methods

--- a/CleverPush/Source/CPAppBannerTextBlock.m
+++ b/CleverPush/Source/CPAppBannerTextBlock.m
@@ -1,5 +1,6 @@
 #import "CPAppBannerTextBlock.h"
 #import "NSDictionary+SafeExpectations.h"
+#import "CPUtils.h"
 
 @implementation CPAppBannerTextBlock
 
@@ -29,6 +30,11 @@
 
         if ([json cleverPushStringForKey:@"family"] && ![[json cleverPushStringForKey:@"family"] isEqual:@""]) {
             self.family = [json cleverPushStringForKey:@"family"];
+        }
+
+        NSString *fontFamilyIos = [json cleverPushStringForKey:@"fontFamilyIos"];
+        if (![CPUtils isNullOrEmpty:fontFamilyIos]) {
+            self.fontFamilyIos = fontFamilyIos;
         }
 
         self.size = 18;

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -310,11 +310,12 @@
         [cell.btnCPBanner setTitleColor:titleColor forState:UIControlStateNormal];
 
         CGFloat fontSize = (CGFloat)(block.size) * 1.2;
-        if ([CPUtils fontFamilyExists:block.family]) {
-            [cell.btnCPBanner.titleLabel setFont:[UIFont fontWithName:block.family size:fontSize]];
+        NSString *resolvedFamily = [CPUtils resolvedFontFamilyWithPlatformFamily:block.fontFamilyIos fallbackFamily:block.family];
+        if (resolvedFamily != nil) {
+            [cell.btnCPBanner.titleLabel setFont:[UIFont fontWithName:resolvedFamily size:fontSize]];
         } else {
-            if (block.family != nil) {
-                [CPLog error:@"Font Family not found for button block: %@", block.family];
+            if (block.fontFamilyIos != nil || block.family != nil) {
+                [CPLog error:@"Font Family not found for button block: %@", block.fontFamilyIos ?: block.family];
             }
             [cell.btnCPBanner.titleLabel setFont:[UIFont systemFontOfSize:fontSize weight:UIFontWeightSemibold]];
         }
@@ -414,11 +415,12 @@
 
         CGFloat fontSize = (CGFloat)(block.size) * 1.2;
         UIFont *font;
-        if ([CPUtils fontFamilyExists:block.family]) {
-            font = [UIFont fontWithName:block.family size:fontSize];
+        NSString *resolvedFamily = [CPUtils resolvedFontFamilyWithPlatformFamily:block.fontFamilyIos fallbackFamily:block.family];
+        if (resolvedFamily != nil) {
+            font = [UIFont fontWithName:resolvedFamily size:fontSize];
         } else {
-            if (block.family != nil) {
-                [CPLog error:@"Font Family not found for text block: %@", block.family];
+            if (block.fontFamilyIos != nil || block.family != nil) {
+                [CPLog error:@"Font Family not found for text block: %@", block.fontFamilyIos ?: block.family];
             }
             font = [UIFont systemFontOfSize:fontSize weight:UIFontWeightSemibold];
         }

--- a/CleverPush/Source/CPInboxDetailContainer.m
+++ b/CleverPush/Source/CPInboxDetailContainer.m
@@ -115,11 +115,12 @@
         [cell.btnCPBanner setTitleColor:titleColor forState:UIControlStateNormal];
 
         CGFloat fontSize = (CGFloat)(block.size) * 1.2;
-        if ([CPUtils fontFamilyExists:block.family]) {
-            [cell.btnCPBanner.titleLabel setFont:[UIFont fontWithName:block.family size:fontSize]];
+        NSString *resolvedFamily = [CPUtils resolvedFontFamilyWithPlatformFamily:block.fontFamilyIos fallbackFamily:block.family];
+        if (resolvedFamily != nil) {
+            [cell.btnCPBanner.titleLabel setFont:[UIFont fontWithName:resolvedFamily size:fontSize]];
         } else {
-            if (block.family != nil) {
-                [CPLog error:@"Font Family not found for button block: %@", block.family];
+            if (block.fontFamilyIos != nil || block.family != nil) {
+                [CPLog error:@"Font Family not found for button block: %@", block.fontFamilyIos ?: block.family];
             }
             [cell.btnCPBanner.titleLabel setFont:[UIFont systemFontOfSize:fontSize weight:UIFontWeightSemibold]];
         }
@@ -194,11 +195,12 @@
 
         CGFloat fontSize = (CGFloat)(block.size) * 1.2;
         UIFont *font;
-        if ([CPUtils fontFamilyExists:block.family]) {
-            font = [UIFont fontWithName:block.family size:fontSize];
+        NSString *resolvedFamily = [CPUtils resolvedFontFamilyWithPlatformFamily:block.fontFamilyIos fallbackFamily:block.family];
+        if (resolvedFamily != nil) {
+            font = [UIFont fontWithName:resolvedFamily size:fontSize];
         } else {
-            if (block.family != nil) {
-                [CPLog error:@"Font Family not found for text block: %@", block.family];
+            if (block.fontFamilyIos != nil || block.family != nil) {
+                [CPLog error:@"Font Family not found for text block: %@", block.fontFamilyIos ?: block.family];
             }
             font = [UIFont systemFontOfSize:fontSize weight:UIFontWeightSemibold];
         }

--- a/CleverPush/Source/CPUtils.h
+++ b/CleverPush/Source/CPUtils.h
@@ -19,6 +19,7 @@
 + (NSDate*)getLastTopicCheckedTime;
 + (NSString *)hexStringFromColor:(UIColor *)color;
 + (BOOL)fontFamilyExists:(NSString*)fontFamily;
++ (NSString *)resolvedFontFamilyWithPlatformFamily:(NSString*)platformFontFamily fallbackFamily:(NSString*)fallbackFontFamily;
 + (BOOL)isEmpty:(id)thing;
 + (void)openSafari:(NSURL*)URL;
 + (CGFloat)frameHeightWithoutSafeArea;

--- a/CleverPush/Source/CPUtils.m
+++ b/CleverPush/Source/CPUtils.m
@@ -269,6 +269,19 @@ NSString * const localeIdentifier = @"en_US_POSIX";
     return [UIFont fontWithName:fontFamily size:18.0f] != nil;
 }
 
+#pragma mark -  Resolve the font family to use, preferring the platform-specific one over the legacy shared one.
++ (NSString *)resolvedFontFamilyWithPlatformFamily:(NSString *)platformFontFamily fallbackFamily:(NSString *)fallbackFontFamily {
+    if ([self fontFamilyExists:platformFontFamily]) {
+        return platformFontFamily;
+    }
+
+    if ([self fontFamilyExists:fallbackFontFamily]) {
+        return fallbackFontFamily;
+    }
+
+    return nil;
+}
+
 #pragma mark -  Check the empty.
 + (BOOL)isEmpty:(id)thing {
     return thing == nil


### PR DESCRIPTION
Added platform-specific font support for In-App Banners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e9410b9d8e101ed09e15696f27c6f593e1f65299. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds iOS-specific font family support for in‑app banner text and buttons by resolving `fontFamilyIos` when provided and falling back to `family`. Ensures correct fonts on iOS while preserving existing configs (CP-11978).

- **New Features**
  - Added `fontFamilyIos` to `CPAppBannerTextBlock` and `CPAppBannerButtonBlock` and parse it from JSON.
  - Introduced `CPUtils resolvedFontFamilyWithPlatformFamily:fallbackFamily:` to prefer iOS font, then fallback.
  - Updated banner/inbox containers to use the resolver, improve missing-font logs, and default to system font when needed.

<sup>Written for commit e9410b9d8e101ed09e15696f27c6f593e1f65299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

