### PR TITLE
feature/cp-12032-cleverpush-campaigns-showing-0-revenue-despite-recorded

### DIFF
--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -3717,9 +3717,15 @@ static id isNil(id object) {
                     NSString* lastClickedNotificationId = [userDefaults stringForKey:CLEVERPUSH_LAST_CLICKED_NOTIFICATION_ID_KEY];
                     NSDate* lastClickedNotificationTimeStamp = [userDefaults objectForKey:CLEVERPUSH_LAST_CLICKED_NOTIFICATION_TIME_KEY];
 
-                    if (![CPUtils isNullOrEmpty:lastClickedNotificationId] && lastClickedNotificationTimeStamp != nil && [lastClickedNotificationTimeStamp isKindOfClass:[NSDate class]]) {
+                    static const NSTimeInterval kNotificationClickValidityInterval = 24 * 60 * 60;
+                    
+                    if (![CPUtils isNullOrEmpty:lastClickedNotificationId] &&
+                        lastClickedNotificationTimeStamp != nil &&
+                        [lastClickedNotificationTimeStamp isKindOfClass:[NSDate class]]) {
+                        
                         NSTimeInterval secondsSinceLastClick = [[NSDate date] timeIntervalSinceDate:lastClickedNotificationTimeStamp];
-                        if (secondsSinceLastClick <= 60 * 60) {
+                        
+                        if (secondsSinceLastClick <= kNotificationClickValidityInterval) {
                             [dataDic setObject:lastClickedNotificationId forKey:@"notificationId"];
                         }
                     }


### PR DESCRIPTION
Extend the notificationId attribution window for /subscription/conversion from 60 minutes to 24 hours.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single attribution timing constant in conversion tracking; no auth or data-schema changes.
> 
> **Overview**
> When `trackEvent` posts to **`subscription/conversion`**, the SDK may attach **`notificationId`** from the last opened push if the click is still within a time window.
> 
> That window is **extended from 1 hour to 24 hours** via `kNotificationClickValidityInterval` (24 × 60 × 60 seconds), so conversions tracked later in the session can still be attributed to the campaign click—addressing cases where campaign revenue showed as zero despite recorded events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe1bab29b4f36f1fad235804f162392057d0bf91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the notificationId attribution window for /subscription/conversion from 60 minutes to 24 hours to correctly credit campaigns for delayed conversions. Addresses CP-12032 where campaigns showed 0 revenue when conversions happened after 1 hour.

<sup>Written for commit fe1bab29b4f36f1fad235804f162392057d0bf91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

