### PR TITLE
hotfix/cp-12117-extern-rate-the-app-styling

### DIFF
--- a/CleverPush/Resources/CPBannerCardContainer.xib
+++ b/CleverPush/Resources/CPBannerCardContainer.xib
@@ -81,8 +81,6 @@
             <connections>
                 <outlet property="bottomViewBannerConstraint" destination="bLb-xk-yLO" id="Uat-HR-inB"/>
                 <outlet property="btnClose" destination="41j-f6-kVw" id="v4p-JA-fg8"/>
-                <outlet property="btnCloseTopConstraint" destination="E6c-Tc-pl3" id="lPn-4M-hAa"/>
-                <outlet property="btnCloseTrailingConstraint" destination="Uo8-1I-STK" id="wRc-6r-eZq"/>
                 <outlet property="centerViewBannerConstraint" destination="GXx-8c-hP5" id="ed4-b9-lZH"/>
                 <outlet property="imgviewBackground" destination="ldd-wZ-7My" id="BeE-rd-8l0"/>
                 <outlet property="pageControl" destination="Xx7-kH-pxc" id="vHX-jN-yhV"/>

--- a/CleverPush/Resources/CPBannerCardContainer.xib
+++ b/CleverPush/Resources/CPBannerCardContainer.xib
@@ -81,6 +81,8 @@
             <connections>
                 <outlet property="bottomViewBannerConstraint" destination="bLb-xk-yLO" id="Uat-HR-inB"/>
                 <outlet property="btnClose" destination="41j-f6-kVw" id="v4p-JA-fg8"/>
+                <outlet property="btnCloseTopConstraint" destination="E6c-Tc-pl3" id="lPn-4M-hAa"/>
+                <outlet property="btnCloseTrailingConstraint" destination="Uo8-1I-STK" id="wRc-6r-eZq"/>
                 <outlet property="centerViewBannerConstraint" destination="GXx-8c-hP5" id="ed4-b9-lZH"/>
                 <outlet property="imgviewBackground" destination="ldd-wZ-7My" id="BeE-rd-8l0"/>
                 <outlet property="pageControl" destination="Xx7-kH-pxc" id="vHX-jN-yhV"/>

--- a/CleverPush/Source/CPAppBannerViewController.m
+++ b/CleverPush/Source/CPAppBannerViewController.m
@@ -521,8 +521,8 @@ static CPAppBannerActionBlock appBannerActionCallback;
     } else if (self.data.type == CPAppBannerTypeBottom) {
         cell.bottomViewBannerConstraint.priority = UILayoutPriorityDefaultHigh;
     } else {
-        cell.topViewBannerConstraint.priority = UILayoutPriorityDefaultHigh;
-        cell.bottomViewBannerConstraint.priority = UILayoutPriorityDefaultHigh;
+        cell.topViewBannerConstraint.priority = UILayoutPriorityRequired;
+        cell.bottomViewBannerConstraint.priority = UILayoutPriorityRequired;
     }
 
     return cell;

--- a/CleverPush/Source/CPAppBannerViewController.m
+++ b/CleverPush/Source/CPAppBannerViewController.m
@@ -521,8 +521,8 @@ static CPAppBannerActionBlock appBannerActionCallback;
     } else if (self.data.type == CPAppBannerTypeBottom) {
         cell.bottomViewBannerConstraint.priority = UILayoutPriorityDefaultHigh;
     } else {
-        cell.topViewBannerConstraint.priority = UILayoutPriorityRequired;
-        cell.bottomViewBannerConstraint.priority = UILayoutPriorityRequired;
+        cell.topViewBannerConstraint.priority = UILayoutPriorityDefaultHigh;
+        cell.bottomViewBannerConstraint.priority = UILayoutPriorityDefaultHigh;
     }
 
     return cell;

--- a/CleverPush/Source/CPBannerCardContainer.h
+++ b/CleverPush/Source/CPBannerCardContainer.h
@@ -25,8 +25,6 @@
 @property (weak, nonatomic) IBOutlet UIImageView *imgviewBackground;
 @property (weak, nonatomic) IBOutlet UIView *viewBannerCardContainer;
 @property (weak, nonatomic) IBOutlet UIButton *btnClose;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *btnCloseTopConstraint;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *btnCloseTrailingConstraint;
 @property (nonatomic, strong) NSMutableArray<CPAppBannerBlock*> *blocks;
 @property (strong, nonatomic) CPAppBanner *data;
 @property (nonatomic, copy) CPAppBannerActionBlock actionCallback;

--- a/CleverPush/Source/CPBannerCardContainer.h
+++ b/CleverPush/Source/CPBannerCardContainer.h
@@ -25,6 +25,8 @@
 @property (weak, nonatomic) IBOutlet UIImageView *imgviewBackground;
 @property (weak, nonatomic) IBOutlet UIView *viewBannerCardContainer;
 @property (weak, nonatomic) IBOutlet UIButton *btnClose;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *btnCloseTopConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *btnCloseTrailingConstraint;
 @property (nonatomic, strong) NSMutableArray<CPAppBannerBlock*> *blocks;
 @property (strong, nonatomic) CPAppBanner *data;
 @property (nonatomic, copy) CPAppBannerActionBlock actionCallback;

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -44,6 +44,13 @@
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
+    if (self.data.type == CPAppBannerTypeFull) {
+        [self setNeedsLayout];
+        [self layoutIfNeeded];
+        [self updateTableViewContentInset];
+        return;
+    }
+
     CGRect frame = self.tblCPBanner.frame;
     CGFloat maxHeight = [CPUtils frameHeightWithoutSafeArea] - 50;
     CGFloat contentHeight = self.tblCPBanner.contentSize.height;
@@ -666,6 +673,16 @@
         if (self.data.closeButtonEnabled && self.data.closeButtonPositionStaticEnabled) {
             self.tblviewTopBannerConstraint.constant = 25;
         }
+    }
+
+    if (self.data.type == CPAppBannerTypeFull) {
+        self.tblCPBannerHeightConstraint.priority = UILayoutPriorityDefaultLow;
+        UIWindow *window = UIApplication.sharedApplication.windows.firstObject;
+        self.topViewBannerConstraint.constant = window.safeAreaInsets.top;
+        self.btnCloseTrailingConstraint.constant = self.btnCloseTopConstraint.constant;
+    } else {
+        self.tblCPBannerHeightConstraint.priority = UILayoutPriorityRequired;
+        self.topViewBannerConstraint.constant = 0;
     }
 }
 

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -677,12 +677,17 @@
 
     if (self.data.type == CPAppBannerTypeFull) {
         self.tblCPBannerHeightConstraint.priority = UILayoutPriorityDefaultLow;
-        UIWindow *window = UIApplication.sharedApplication.windows.firstObject;
-        self.topViewBannerConstraint.constant = window.safeAreaInsets.top;
+        if (self.data.marginEnabled) {
+            self.topViewBannerConstraint.constant = 0;
+        } else {
+            UIWindow *window = UIApplication.sharedApplication.windows.firstObject;
+            self.topViewBannerConstraint.constant = window.safeAreaInsets.top;
+        }
         self.btnCloseTrailingConstraint.constant = self.btnCloseTopConstraint.constant;
     } else {
         self.tblCPBannerHeightConstraint.priority = UILayoutPriorityRequired;
         self.topViewBannerConstraint.constant = 0;
+        self.btnCloseTrailingConstraint.constant = 10;
     }
 }
 

--- a/CleverPush/Source/CPBannerCardContainer.m
+++ b/CleverPush/Source/CPBannerCardContainer.m
@@ -44,13 +44,6 @@
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
-    if (self.data.type == CPAppBannerTypeFull) {
-        [self setNeedsLayout];
-        [self layoutIfNeeded];
-        [self updateTableViewContentInset];
-        return;
-    }
-
     CGRect frame = self.tblCPBanner.frame;
     CGFloat maxHeight = [CPUtils frameHeightWithoutSafeArea] - 50;
     CGFloat contentHeight = self.tblCPBanner.contentSize.height;
@@ -673,16 +666,6 @@
         if (self.data.closeButtonEnabled && self.data.closeButtonPositionStaticEnabled) {
             self.tblviewTopBannerConstraint.constant = 25;
         }
-    }
-
-    if (self.data.type == CPAppBannerTypeFull) {
-        self.tblCPBannerHeightConstraint.priority = UILayoutPriorityDefaultLow;
-        UIWindow *window = UIApplication.sharedApplication.windows.firstObject;
-        self.topViewBannerConstraint.constant = window.safeAreaInsets.top;
-        self.btnCloseTrailingConstraint.constant = self.btnCloseTopConstraint.constant;
-    } else {
-        self.tblCPBannerHeightConstraint.priority = UILayoutPriorityRequired;
-        self.topViewBannerConstraint.constant = 0;
     }
 }
 


### PR DESCRIPTION
Resolved the close button UI Positing issue in appBanners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI/Auto Layout changes for full-screen banners only; no auth, data, or networking impact.
> 
> **Overview**
> Fixes **full-screen app banner** layout so the close control matches expected styling (e.g. “Rate the app”) by wiring **close button top/trailing constraints** in `CPBannerCardContainer` and adjusting them at runtime.
> 
> For **`CPAppBannerTypeFull`**, the collection cell now pins the banner with **required** top/bottom constraints so the card fills the cell, lowers the table **height constraint priority** so content can stretch, and applies **safe-area top inset** (when margins are off) plus **symmetric** close-button spacing (`trailing` matches `top`). Table **content-size** observation skips height clamping for full-screen and instead **relayouts** and refreshes insets; **`willDisplayCell`** also forces layout/insets when cells appear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31d69cf0343f6af8e91365feb97bb51da2a0b01d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent close button placement on full‑screen app banners and applies safe‑area spacing to match the “Rate the app” styling (CP‑12117). Ensures the banner fills its cell so the close button sits at a stable, symmetric offset.

- **Bug Fixes**
  - Make banner top/bottom constraints required for full‑screen so it fills the cell.
  - Let the table view stretch by lowering its height constraint priority for full‑screen; keep it required otherwise.
  - Apply safe‑area top inset for full‑screen unless `marginEnabled` is on; sync close button trailing with its top spacing.
  - For full‑screen, relayout and update content insets after layout to keep positions stable.

<sup>Written for commit 31d69cf0343f6af8e91365feb97bb51da2a0b01d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

