### PR TITLE
feature/cp-12191-support-provisional-push-notifications-on-ios

### DIFF
--- a/CleverPush/Source/CleverPush.h
+++ b/CleverPush/Source/CleverPush.h
@@ -166,6 +166,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 + (void)setBadgeCountEnabledForNotifications:(BOOL)enabled;
 + (void)setIgnoreDisabledNotificationPermission:(BOOL)ignore;
 + (void)setAutoRequestNotificationPermission:(BOOL)autoRequest;
++ (void)setProvisionalNotificationAuthorizationEnabled:(BOOL)enabled;
 + (void)setKeepTargetingDataOnUnsubscribe:(BOOL)keepData;
 + (void)addChatView:(CPChatView* _Nullable)chatView;
 + (void)showTopicsDialog;

--- a/CleverPush/Source/CleverPush.m
+++ b/CleverPush/Source/CleverPush.m
@@ -535,6 +535,10 @@ static CleverPush* singleInstance = nil;
     [self.CPSharedInstance setAutoRequestNotificationPermission:autoRequest];
 }
 
++ (void)setProvisionalNotificationAuthorizationEnabled:(BOOL)enabled {
+    [self.CPSharedInstance setProvisionalNotificationAuthorizationEnabled:enabled];
+}
+
 + (void)setKeepTargetingDataOnUnsubscribe:(BOOL)keepData {
     [self.CPSharedInstance setKeepTargetingDataOnUnsubscribe:keepData];
 }

--- a/CleverPush/Source/CleverPushInstance.h
+++ b/CleverPush/Source/CleverPushInstance.h
@@ -199,6 +199,7 @@ extern NSString* _Nullable const CLEVERPUSH_SDK_VERSION;
 - (void)setBadgeCountEnabledForNotifications:(BOOL)enabled;
 - (void)setIgnoreDisabledNotificationPermission:(BOOL)ignore;
 - (void)setAutoRequestNotificationPermission:(BOOL)autoRequest;
+- (void)setProvisionalNotificationAuthorizationEnabled:(BOOL)enabled;
 - (void)setKeepTargetingDataOnUnsubscribe:(BOOL)keepData;
 - (void)addChatView:(CPChatView* _Nullable)chatView;
 - (void)showTopicsDialog;

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -90,6 +90,7 @@ static BOOL autoRegister = YES;
 static BOOL registrationInProgress = false;
 static BOOL ignoreDisabledNotificationPermission = NO;
 static BOOL autoRequestNotificationPermission = YES;
+static BOOL isProvisionalNotificationAuthorizationEnabled = NO;
 static BOOL keepTargetingDataOnUnsubscribe = NO;
 static BOOL hasCalledSubscribe = NO;
 static BOOL isSessionStartCalled = NO;
@@ -1178,7 +1179,8 @@ static id isNil(id object) {
 #pragma mark - Returns if the user has currently given the notification permission
 - (void)areNotificationsEnabled:(void(^ _Nullable)(BOOL))callback {
     [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *_Nonnull notificationSettings) {
-        BOOL isEnabled = (notificationSettings.authorizationStatus == UNAuthorizationStatusAuthorized);
+        BOOL isEnabled = (notificationSettings.authorizationStatus == UNAuthorizationStatusAuthorized) ||
+            (notificationSettings.authorizationStatus == UNAuthorizationStatusProvisional);
         if (callback) {
             callback(isEnabled);
         }
@@ -1270,6 +1272,11 @@ static id isNil(id object) {
     }
     if (shouldSetBadge) {
         options |= UNAuthorizationOptionBadge;
+    }
+    if (@available(iOS 12.0, *)) {
+        if (isProvisionalNotificationAuthorizationEnabled) {
+            options |= UNAuthorizationOptionProvisional;
+        }
     }
 
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
@@ -4546,6 +4553,10 @@ static id isNil(id object) {
 
 - (void)setAutoRequestNotificationPermission:(BOOL)autoRequest {
     autoRequestNotificationPermission = autoRequest;
+}
+
+- (void)setProvisionalNotificationAuthorizationEnabled:(BOOL)enabled {
+    isProvisionalNotificationAuthorizationEnabled = enabled;
 }
 
 - (void)setKeepTargetingDataOnUnsubscribe:(BOOL)keepData {

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1179,8 +1179,10 @@ static id isNil(id object) {
 #pragma mark - Returns if the user has currently given the notification permission
 - (void)areNotificationsEnabled:(void(^ _Nullable)(BOOL))callback {
     [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *_Nonnull notificationSettings) {
-        BOOL isEnabled = (notificationSettings.authorizationStatus == UNAuthorizationStatusAuthorized) ||
-            (notificationSettings.authorizationStatus == UNAuthorizationStatusProvisional);
+        BOOL isEnabled = (notificationSettings.authorizationStatus == UNAuthorizationStatusAuthorized);
+        if (@available(iOS 12.0, *)) {
+            isEnabled = isEnabled || (notificationSettings.authorizationStatus == UNAuthorizationStatusProvisional);
+        }
         if (callback) {
             callback(isEnabled);
         }


### PR DESCRIPTION
Added `setProvisionalNotificationAuthorizationEnabled` method to support Apple's provisional push authorisation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in change to notification permission options and status checks; default behavior is unchanged.
> 
> **Overview**
> Adds **opt-in support for iOS 12+ provisional push authorization** via `setProvisionalNotificationAuthorizationEnabled(BOOL)` on `CleverPush` and `CleverPushInstance`, wired through the same static-flag pattern as other notification settings.
> 
> When enabled, the SDK includes **`UNAuthorizationOptionProvisional`** in permission requests alongside existing alert/sound/badge options. **`areNotificationsEnabled`** now treats **`UNAuthorizationStatusProvisional`** as enabled, not only fully authorized status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e4bc2e5ed2405dde786ccf27a4fc286f22d0cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Apple's provisional push notifications on iOS 12+ by adding an opt-in API and counting provisional status as enabled during permission checks. Implements Linear CP-12191.

- **New Features**
  - Added `setProvisionalNotificationAuthorizationEnabled(BOOL)` on `CleverPush` and `CleverPushInstance`.
  - When enabled (iOS 12+), permission requests include `UNAuthorizationOptionProvisional`.
  - `areNotificationsEnabled` returns true for `UNAuthorizationStatusProvisional`.

<sup>Written for commit 95e4bc2e5ed2405dde786ccf27a4fc286f22d0cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

