### PR TITLE
hotfix/cp-6153-androidios-optimize-customer-listener

### DIFF
--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -81,7 +81,9 @@ CPNotificationClickBlock handleClick;
                     [CleverPush getChannelConfig:^(NSDictionary *config) {
                         NSString *channelIcon = [config cleverPushStringForKey:@"channelIcon"];
                         if (channelIcon != nil && ![channelIcon isKindOfClass:[NSNull class]]) {
-                            self.notificationThumbnail = channelIcon;
+                            dispatch_async(dispatch_get_main_queue(), ^{
+                                self.notificationThumbnail = channelIcon;
+                            });
                         }
                     }];
                     self.messageList = [[UITableView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width , frame.size.height)];
@@ -453,15 +455,18 @@ CPNotificationClickBlock handleClick;
     [CleverPush enqueueRequest:request onSuccess:^(NSDictionary* result) {
         NSMutableArray *jsonBanners = [[NSMutableArray alloc] init];
 
-        NSPredicate *predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[[NSPredicate predicateWithFormat:[NSString stringWithFormat:@"SELF contains '%@'", bannerId]]]];
-        jsonBanners = [[[result objectForKey:@"banners"] filteredArrayUsingPredicate:predicate] mutableCopy];
-
+        id bannersValue = [result objectForKey:@"banners"];
+        if (bannersValue != nil && [bannersValue isKindOfClass:[NSArray class]]) {
+            NSPredicate *predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[[NSPredicate predicateWithFormat:[NSString stringWithFormat:@"SELF contains '%@'", bannerId]]]];
+            jsonBanners = [[bannersValue filteredArrayUsingPredicate:predicate] mutableCopy];
+        } else {
+            [CPLog error:@"CPInboxView getBanners: 'banners' key missing or not an array in response"];
+        }
 
         if (jsonBanners != nil) {
             if (notificationId && callback) {
                 callback(jsonBanners);
             }
-
         }
     } onFailure:^(NSError* error) {
         [CPLog error:@"Failed getting app banners %@", error];

--- a/CleverPush/Source/CPInboxView.m
+++ b/CleverPush/Source/CPInboxView.m
@@ -78,14 +78,6 @@ CPNotificationClickBlock handleClick;
                         self.divider_colour = [UIColor lightGrayColor];
                     }
 
-                    [CleverPush getChannelConfig:^(NSDictionary *config) {
-                        NSString *channelIcon = [config cleverPushStringForKey:@"channelIcon"];
-                        if (channelIcon != nil && ![channelIcon isKindOfClass:[NSNull class]]) {
-                            dispatch_async(dispatch_get_main_queue(), ^{
-                                self.notificationThumbnail = channelIcon;
-                            });
-                        }
-                    }];
                     self.messageList = [[UITableView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width , frame.size.height)];
                     NSBundle *bundle = [CPUtils getAssetsBundle];
                     if (bundle) {
@@ -101,6 +93,16 @@ CPNotificationClickBlock handleClick;
                     if (self.notifications.count == 0) {
                         [self presentEmptyView:frame];
                     }
+
+                    [CleverPush getChannelConfig:^(NSDictionary *config) {
+                        NSString *channelIcon = [config cleverPushStringForKey:@"channelIcon"];
+                        if (channelIcon != nil && ![channelIcon isKindOfClass:[NSNull class]]) {
+                            dispatch_async(dispatch_get_main_queue(), ^{
+                                self.notificationThumbnail = channelIcon;
+                                [self.messageList reloadData];
+                            });
+                        }
+                    }];
                 });
 
             }];
@@ -453,20 +455,17 @@ CPNotificationClickBlock handleClick;
 
     NSMutableURLRequest* request = [[CleverPushHTTPClient sharedClient] requestWithMethod:HTTP_GET path:bannersPath];
     [CleverPush enqueueRequest:request onSuccess:^(NSDictionary* result) {
-        NSMutableArray *jsonBanners = [[NSMutableArray alloc] init];
-
         id bannersValue = [result objectForKey:@"banners"];
-        if (bannersValue != nil && [bannersValue isKindOfClass:[NSArray class]]) {
-            NSPredicate *predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[[NSPredicate predicateWithFormat:[NSString stringWithFormat:@"SELF contains '%@'", bannerId]]]];
-            jsonBanners = [[bannersValue filteredArrayUsingPredicate:predicate] mutableCopy];
-        } else {
+        if (bannersValue == nil || ![bannersValue isKindOfClass:[NSArray class]]) {
             [CPLog error:@"CPInboxView getBanners: 'banners' key missing or not an array in response"];
+            return;
         }
 
-        if (jsonBanners != nil) {
-            if (notificationId && callback) {
-                callback(jsonBanners);
-            }
+        NSPredicate *predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[[NSPredicate predicateWithFormat:[NSString stringWithFormat:@"SELF contains '%@'", bannerId]]]];
+        NSMutableArray *jsonBanners = [[bannersValue filteredArrayUsingPredicate:predicate] mutableCopy];
+
+        if (notificationId && callback) {
+            callback(jsonBanners);
         }
     } onFailure:^(NSError* error) {
         [CPLog error:@"Failed getting app banners %@", error];

--- a/CleverPush/Source/CPWidgetModule.m
+++ b/CleverPush/Source/CPWidgetModule.m
@@ -18,7 +18,7 @@
     [CleverPush enqueueRequest:request onSuccess:^(NSDictionary* result) {
         if (result != nil) {
             CPWidgetsStories *widgets = [[CPWidgetsStories alloc] initWithJson:result];
-            if (widgets != nil) {
+            if (widgets != nil && callback) {
                 callback(widgets);
                 return;
             }

--- a/CleverPush/Source/CleverPush.m
+++ b/CleverPush/Source/CleverPush.m
@@ -338,13 +338,17 @@ static CleverPush* singleInstance = nil;
 
 + (void)addSubscriptionTag:(NSString* _Nullable)tagId callback:(void(^ _Nullable)(NSString* _Nullable))callback {
     [self.CPSharedInstance addSubscriptionTag:tagId callback:^(NSString*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     }];
 }
 
 + (void)addSubscriptionTag:(NSString* _Nullable)tagId callback:(void(^ _Nullable)(NSString* _Nullable))callback onFailure:(CPFailureBlock _Nullable)failureBlock {
     [self.CPSharedInstance addSubscriptionTag:tagId callback:^(NSString*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     } onFailure:failureBlock];
 }
 
@@ -355,7 +359,9 @@ static CleverPush* singleInstance = nil;
 
 + (void)addSubscriptionTags:(NSArray <NSString*>* _Nullable)tagIds callback:(void(^ _Nullable)(NSArray <NSString*>* _Nullable))callback {
     [self.CPSharedInstance addSubscriptionTags:tagIds callback:^(NSArray*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     }];
 }
 
@@ -365,13 +371,17 @@ static CleverPush* singleInstance = nil;
 
 + (void)removeSubscriptionTag:(NSString* _Nullable)tagId callback:(void(^ _Nullable)(NSString* _Nullable))callback {
     [self.CPSharedInstance removeSubscriptionTag:tagId callback:^(NSString*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     }];
 }
 
 + (void)removeSubscriptionTag:(NSString* _Nullable)tagId callback:(void(^ _Nullable)(NSString* _Nullable))callback onFailure:(CPFailureBlock _Nullable)failureBlock {
     [self.CPSharedInstance removeSubscriptionTag:tagId callback:^(NSString*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     } onFailure:failureBlock];
 }
 
@@ -381,7 +391,9 @@ static CleverPush* singleInstance = nil;
 
 + (void)removeSubscriptionTags:(NSArray <NSString*>* _Nullable)tagIds callback:(void(^ _Nullable)(NSArray <NSString*>* _Nullable))callback {
     [self.CPSharedInstance removeSubscriptionTags:tagIds callback:^(NSArray*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     }];
 }
 
@@ -455,19 +467,25 @@ static CleverPush* singleInstance = nil;
 
 + (void)getAvailableTags:(void(^ _Nullable)(NSArray <CPChannelTag*>*))callback {
     [self.CPSharedInstance getAvailableTags:^(NSArray*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     }];
 }
 
 + (void)getAvailableTopics:(void(^ _Nullable)(NSArray <CPChannelTopic*>*))callback {
     [self.CPSharedInstance getAvailableTopics:^(NSArray*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     }];
 }
 
 + (void)getAvailableAttributes:(void(^ _Nullable)(NSMutableArray* _Nullable))callback {
     [self.CPSharedInstance getAvailableAttributes:^(NSMutableArray*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     }];
 }
 
@@ -581,13 +599,17 @@ static CleverPush* singleInstance = nil;
 
 + (void)getChannelConfig:(void(^ _Nullable)(NSDictionary* _Nullable))callback {
     [self.CPSharedInstance getChannelConfig:^(NSDictionary*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     }];
 }
 
 + (void)getSubscriptionId:(void(^ _Nullable)(NSString* _Nullable))callback {
     [self.CPSharedInstance getSubscriptionId:^(NSString*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     }];
 }
 
@@ -637,31 +659,41 @@ static CleverPush* singleInstance = nil;
 
 + (void)setAppBannerOpenedCallback:(CPAppBannerActionBlock _Nullable)callback {
     [self.CPSharedInstance setAppBannerOpenedCallback:^(CPAppBannerAction*action) {
-        callback(action);
+        if (callback) {
+            callback(action);
+        }
     }];
 }
 
 + (void)setAppBannerShownCallback:(CPAppBannerShownBlock _Nullable)callback {
     [self.CPSharedInstance setAppBannerShownCallback:^(CPAppBanner*appBanner) {
-        callback(appBanner);
+        if (callback) {
+            callback(appBanner);
+        }
     }];
 }
 
 + (void)setShowAppBannerCallback:(CPAppBannerDisplayBlock _Nullable)callback {
     [self.CPSharedInstance setShowAppBannerCallback:^(UIViewController*viewController) {
-        callback(viewController);
+        if (callback) {
+            callback(viewController);
+        }
     }];
 }
 
 + (void)getAppBanners:(NSString* _Nullable)channelId callback:(void(^ _Nullable)(NSMutableArray <CPAppBanner*>* _Nullable))callback {
     [self.CPSharedInstance getAppBanners:channelId callback:^(NSMutableArray*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     }];
 }
 
 + (void)getAppBannersByGroup:(NSString* _Nullable)groupId callback:(void(^ _Nullable)(NSMutableArray <CPAppBanner*>* _Nullable))callback {
     [self.CPSharedInstance getAppBannersByGroup:groupId callback:^(NSMutableArray*callbackInner) {
-        callback(callbackInner);
+        if (callback) {
+            callback(callbackInner);
+        }
     }];
 }
 

--- a/CleverPush/Source/CleverPushInstance.m
+++ b/CleverPush/Source/CleverPushInstance.m
@@ -1528,10 +1528,14 @@ static id isNil(id object) {
         [self enqueueRequest:request onSuccess:^(NSDictionary* result) {
             [self setUnsubscribeStatus:YES];
             [self clearSubscriptionData];
-            callback(YES);
+            if (callback) {
+                callback(YES);
+            }
         } onFailure:^(NSError* error) {
             [self clearSubscriptionData];
-            callback(NO);
+            if (callback) {
+                callback(NO);
+            }
             if (failureBlock) {
                 failureBlock(error);
             }
@@ -1539,7 +1543,9 @@ static id isNil(id object) {
 
     } else {
         [self clearSubscriptionData];
-        callback(YES);
+        if (callback) {
+            callback(YES);
+        }
     }
 }
 
@@ -2411,11 +2417,19 @@ static id isNil(id object) {
         } else {
             NSMutableDictionary*requestParameters = [[NSJSONSerialization JSONObjectWithData:[urlRequest HTTPBody] options:0 error:&error] mutableCopy];
             if (error) {
+                [CPLog error:@"enqueueRequest: Failed to parse request body JSON: %@", error];
+                if (failureBlock) {
+                    failureBlock(error);
+                }
                 return;
             }
             [requestParameters setObject:authorizationToken forKey:@"authorizationToken"];
             NSData*updatedRequestData = [NSJSONSerialization dataWithJSONObject:requestParameters options:0 error:&error];
             if (error) {
+                [CPLog error:@"enqueueRequest: Failed to re-serialize request body JSON: %@", error];
+                if (failureBlock) {
+                    failureBlock(error);
+                }
                 return;
             }
             [urlRequest setHTTPBody:updatedRequestData];


### PR DESCRIPTION
Optimized callback functions for preventing crashes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide surface area on public callback APIs and changed failure behavior when request body JSON is invalid; low security impact but integrators may see new failure callbacks where calls previously no-oped.
> 
> **Overview**
> **Crash prevention** across the CleverPush iOS SDK by only invoking optional completion/callback blocks when they are non-nil, and by tightening a few async/UI paths.
> 
> **CPInboxView** defers channel icon loading until after the table is set up, applies `notificationThumbnail` on the **main queue**, and calls `reloadData` so cells pick up the default icon. **getBanners** now requires `result[@"banners"]` to be an `NSArray` (logs and bails otherwise) instead of filtering a missing/wrong type.
> 
> **CleverPush** façade methods (tags, topics, attributes, channel config, subscription id, app banner callbacks, etc.) wrap passthrough callbacks with nil checks. **CleverPushInstance** does the same for unsubscribe callbacks; **enqueueRequest** logs JSON body parse/re-serialize failures and invokes `failureBlock` instead of returning silently.
> 
> **CPWidgetModule** only calls `completion` when both the parsed widgets object and the block are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8dae04835485eb436bb8b1e46796ef0f7940b34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes in the iOS SDK by guarding optional callbacks, moving inbox UI updates to the main thread, and validating request/response JSON (CP-6153). Previously we invoked nil callbacks, updated UI off-main, and silently dropped JSON errors; now we check for non-nil callbacks, dispatch UI work to the main queue, and log and surface failures.

- CPInboxView: set the channel icon (`notificationThumbnail`) on the main queue and reload the table; in `getBanners`, confirm `banners` is an array, log on invalid responses, and return early without invoking the callback.
- CPWidgetModule: only invoke the widgets stories `completion` when it is non-nil.
- CleverPush static APIs: add nil checks around all callback passthroughs (tags, topics, attributes, channel config, subscription ID, app banners).
- CleverPushInstance: in `unsubscribe`, guard callback invocations; in `enqueueRequest`, log and call `failureBlock` on JSON parse/serialize errors instead of returning silently.

- Rollout: callers may now receive `failureBlock` invocations for malformed request bodies, and banner fetch will not call back on invalid responses; no migration required.

<sup>Written for commit d8dae04835485eb436bb8b1e46796ef0f7940b34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-ios-sdk/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

